### PR TITLE
Fix Cloudflare-blocked frontend vendor chunk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,14 @@ jobs:
         timeout-minutes: 10
         run: npm run build
 
+      - name: Guard Cloudflare-blocked asset names
+        run: |
+          set -euo pipefail
+          if grep -R '/assets/vendor-' dist/index.html dist/assets 2>/dev/null; then
+            echo "The deployed Cloudflare zone blocks /assets/vendor-*.js. Rename the chunk before merging."
+            exit 1
+          fi
+
       - name: Typecheck changed files
         timeout-minutes: 5
         run: npm run typecheck:changed

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,7 +44,7 @@ export default defineConfig(({ mode }) => {
         output: {
           // iOS Safari를 위한 청크 분할 최적화
           manualChunks: {
-            vendor: ["react", "react-dom"],
+            reactCore: ["react", "react-dom"],
             router: ["react-router-dom"]
           },
           // 🔒 파일명 해싱으로 추측 방지


### PR DESCRIPTION
## Summary
- Rename the explicit React runtime chunk from vendor to reactCore because Cloudflare blocks /assets/vendor-*.js on the production zone
- Add a frontend CI guard that fails if the built dist output references /assets/vendor-

## Verification
- npm run build
- grep -R '/assets/vendor-' dist/index.html dist/assets returned no matches
- FAIRPLAY_CHECK_BASE=origin/develop npm run verify:changed
- GITHUB_EVENT_NAME=push FAIRPLAY_CHECK_BASE=origin/develop npm run verify:changed

## Production symptom
- https://fairplay.rktclgh.site served HTML, main JS, router JS, and /api/events with 200
- /assets/vendor-CY5KFkx3.js returned Cloudflare 403, preventing React from booting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 빌드 프로세스에 자동 검증 단계 추가로 배포 전 문제 조기 감지
* 번들 청크 네이밍 최적화로 CDN 호환성 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rktclgh/FairPlay_FE/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->