### PR TITLE
Promote Cloudflare frontend chunk hotfix

### DIFF
--- a/.env.miniserver.example
+++ b/.env.miniserver.example
@@ -1,0 +1,7 @@
+VITE_BACKEND_BASE_URL=https://fairplay.rktclgh.site
+VITE_FRONTEND_BASE_URL=https://fairplay.rktclgh.site
+VITE_CDN_BASE_URL=https://fairplay.rktclgh.site/uploads
+VITE_ENABLE_NEW_PICKS=false
+VITE_KAKAO_CLIENT_ID=change-me
+VITE_KAKAO_MAP_ID=change-me
+VITE_BUSINESS_SERVICE_KEY=change-me

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,14 @@ jobs:
         timeout-minutes: 10
         run: npm run build
 
+      - name: Guard Cloudflare-blocked asset names
+        run: |
+          set -euo pipefail
+          if grep -R '/assets/vendor-' dist/index.html dist/assets 2>/dev/null; then
+            echo "The deployed Cloudflare zone blocks /assets/vendor-*.js. Rename the chunk before merging."
+            exit 1
+          fi
+
       - name: Typecheck changed files
         timeout-minutes: 5
         run: npm run typecheck:changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: frontend-ci
+
+on:
+  pull_request:
+    branches: [ "develop", "main" ]
+  push:
+    branches: [ "develop" ]
+
+permissions:
+  contents: read
+
+jobs:
+  lint-and-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        timeout-minutes: 10
+        run: npm run build
+
+      - name: Typecheck changed files
+        timeout-minutes: 5
+        run: npm run typecheck:changed
+
+      - name: Lint changed files
+        timeout-minutes: 5
+        run: npm run lint:changed

--- a/.github/workflows/notify-backend.yml
+++ b/.github/workflows/notify-backend.yml
@@ -4,15 +4,19 @@ on:
   push:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
-      - name: Notify BE repo via repository_dispatch
+      - name: Dispatch BE main deploy workflow
         run: |
-          curl -L \
+          set -euo pipefail
+          curl -fsSL \
             -X POST \
             -H "Authorization: token ${{ secrets.CI_GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/rktclgh/FairPlay_BE/dispatches \
-            -d '{"event_type":"fe-updated","client_payload":{"fe_ref":"main"}}'
+            https://api.github.com/repos/rktclgh/FairPlay_BE/actions/workflows/deploy-main.yml/dispatches \
+            -d '{"ref":"main","inputs":{"fe_ref":"main"}}'

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
+    "lint:changed": "node scripts/check-changed.mjs lint",
+    "typecheck:changed": "node scripts/check-changed.mjs typecheck",
+    "verify:changed": "node scripts/check-changed.mjs all",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/scripts/check-changed.mjs
+++ b/scripts/check-changed.mjs
@@ -1,0 +1,80 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+
+const mode = process.argv[2] ?? "all";
+const baseRef = process.env.GITHUB_BASE_REF || process.env.FAIRPLAY_CHECK_BASE || "develop";
+
+function git(args) {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+function resolveBase() {
+  const refCandidates = baseRef.startsWith("origin/")
+    ? [baseRef, "HEAD^"]
+    : [`origin/${baseRef}`, baseRef, "HEAD^"];
+  const candidates = process.env.GITHUB_EVENT_NAME === "push"
+    ? ["HEAD^", ...refCandidates]
+    : refCandidates;
+  for (const candidate of candidates) {
+    try {
+      return git(["merge-base", candidate, "HEAD"]);
+    } catch {
+      // Try the next candidate. CI uses fetch-depth 0 so origin/base should exist.
+    }
+  }
+  throw new Error(`Unable to resolve a diff base for ${baseRef}`);
+}
+
+function changedFiles() {
+  const base = resolveBase();
+  return git(["diff", "--name-only", "--diff-filter=ACMR", `${base}...HEAD`])
+    .split("\n")
+    .map((file) => file.trim())
+    .filter(Boolean);
+}
+
+function run(command, args) {
+  console.log(`$ ${command} ${args.join(" ")}`);
+  execFileSync(command, args, { stdio: "inherit" });
+}
+
+const files = changedFiles();
+const lintFiles = files.filter((file) => /\.(cjs|mjs|js|jsx|ts|tsx)$/.test(file));
+const typecheckFiles = files.filter((file) => /\.(ts|tsx)$/.test(file));
+const typecheckInputs = [...typecheckFiles];
+
+if (typecheckFiles.length > 0 && existsSync("src/vite-env.d.ts") && !typecheckInputs.includes("src/vite-env.d.ts")) {
+  typecheckInputs.unshift("src/vite-env.d.ts");
+}
+
+if ((mode === "lint" || mode === "all") && lintFiles.length > 0) {
+  run("./node_modules/.bin/eslint", [...lintFiles]);
+}
+
+if ((mode === "typecheck" || mode === "all") && typecheckInputs.length > 0) {
+  run("./node_modules/.bin/tsc", [
+    "--noEmit",
+    "--skipLibCheck",
+    "--target",
+    "ES2022",
+    "--module",
+    "ESNext",
+    "--moduleResolution",
+    "bundler",
+    "--jsx",
+    "react-jsx",
+    "--strict",
+    "--allowImportingTsExtensions",
+    "--verbatimModuleSyntax",
+    "false",
+    "--noUnusedLocals",
+    "false",
+    "--noUnusedParameters",
+    "false",
+    ...typecheckInputs,
+  ]);
+}
+
+if ((mode === "lint" && lintFiles.length === 0) || (mode === "typecheck" && typecheckFiles.length === 0)) {
+  console.log(`No changed files for ${mode}.`);
+}

--- a/src/components/chat/ChatRoomList.tsx
+++ b/src/components/chat/ChatRoomList.tsx
@@ -82,7 +82,7 @@ export default function ChatRoomList({ onSelect }: Props) {
         const sockjsUrl = window.location.hostname === 'localhost'
             ? `${import.meta.env.VITE_BACKEND_BASE_URL}/ws/chat-sockjs`
             : `${window.location.protocol}//${window.location.host}/ws/chat-sockjs`;
-        const sock = new SockJS(sockjsUrl, [], { withCredentials: true });
+        const sock = new SockJS(sockjsUrl);
         const stomp = Stomp.over(sock);
         stomp.debug = () => { };
         clientRef.current = stomp;
@@ -204,4 +204,3 @@ export default function ChatRoomList({ onSelect }: Props) {
         </div>
     );
 }
-

--- a/src/components/chat/useChatSocket.ts
+++ b/src/components/chat/useChatSocket.ts
@@ -74,8 +74,7 @@ export function useChatSocket(
         
         console.log(`SockJS connecting to: ${sockjsUrl}`);
         
-        const sock = new SockJS(sockjsUrl, [], { 
-          withCredentials: true,
+        const sock = new SockJS(sockjsUrl, [], {
           transports: ['websocket', 'xhr-streaming', 'xhr-polling']
         });
         const stomp = Stomp.over(sock);
@@ -97,7 +96,7 @@ export function useChatSocket(
         }, 10000);
         clientRef.current = stomp;
 
-        const connectHeaders: any = {};
+        const connectHeaders: Record<string, string> = {};
 
         stomp.connect(
           connectHeaders,
@@ -190,9 +189,8 @@ export function useChatSocket(
                 `WebSocket 재연결 시도 ${reconnectAttempts.current}/${maxReconnectAttempts} (${reconnectDelay}ms 후)`
               );
 
-              setTimeout(async () => {
-                const stillAuthenticated = isAuthenticated();
-                if (stillAuthenticated && isMountedRef.current) {
+              setTimeout(() => {
+                if (isAuthenticated && isMountedRef.current) {
                   console.log(`실제 재연결 시도 ${reconnectAttempts.current}/${maxReconnectAttempts}`);
                   isConnectedRef.current = false;
                   

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
 import api from '../api/axios';
 import presenceManager from '../utils/presenceManager';
 
@@ -44,9 +45,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         };
       }
       return null;
-    } catch (error: any) {
+    } catch (error: unknown) {
       // Silent 인증에서는 401 에러를 조용히 처리
-      if (error.response?.status === 401) {
+      if (axios.isAxiosError(error) && error.response?.status === 401) {
         return null;
       }
       console.error('AuthContext fetchUserInfo 에러:', error);
@@ -162,17 +163,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       console.log('🔧 AuthContext 초기화 시작');
       setLoading(true);
 
-      // 쿠키 확인: 세션이 있는 경우에만 API 호출
-      const hasSessionCookie = document.cookie.includes('FAIRPLAY_SESSION');
-
-      if (hasSessionCookie) {
-        console.log('🍪 세션 쿠키 발견, 인증 상태 확인');
-        await checkAuth();
-      } else {
-        console.log('🚫 세션 쿠키 없음, 비로그인 상태로 설정');
-        setIsAuthenticated(false);
-        setUser(null);
-      }
+      // HTTP-only 세션 쿠키는 JS에서 읽을 수 없으므로 서버에 silent 확인을 바로 보낸다.
+      await checkAuth();
 
       if (isMounted) {
         setLoading(false);
@@ -223,6 +215,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   );
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useAuth(): AuthContextType {
   const context = useContext(AuthContext);
   if (context === undefined) {

--- a/src/utils/authGuard.ts
+++ b/src/utils/authGuard.ts
@@ -1,17 +1,11 @@
-import { NavigateFunction } from 'react-router-dom';
+import type { NavigateFunction } from 'react-router-dom';
 
 // AuthContext 없이 사용할 수 있는 레거시 함수들
 // 새로운 코드에서는 useAuth() 훅을 사용하는 것을 권장
 
-// 빠른 쿠키 체크 (동기)
+// HTTP-only FAIRPLAY_SESSION cannot be inspected from JavaScript.
+// Keep this legacy sync helper fail-closed; use AuthContext for real auth state.
 export const isAuthenticated = (): boolean => {
-  const cookies = document.cookie.split(';');
-  for (let cookie of cookies) {
-    const [name] = cookie.trim().split('=');
-    if (name === 'FAIRPLAY_SESSION') {
-      return true;
-    }
-  }
   return false;
 };
 
@@ -22,7 +16,7 @@ export const requireAuth = (
   feature: string = '기능'
 ): boolean => {
   if (!isAuth) {
-    alert(`로그인이 필요한 서비스입니다.`);
+    alert(`${feature}은(는) 로그인이 필요한 서비스입니다.`);
     navigate('/login');
     return false;
   }

--- a/src/utils/tokenValidator.ts
+++ b/src/utils/tokenValidator.ts
@@ -1,6 +1,4 @@
-// tokenValidator.ts - 간단한 쿠키 체크만 담당 (AuthContext와 중복 제거)
-
-import { isAuthenticated } from './authGuard';
+// tokenValidator.ts - AuthContext owns HTTP-only session validation.
 
 class TokenValidator {
   private static instance: TokenValidator;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,5 +1,10 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+    readonly VITE_BACKEND_BASE_URL: string;
+    readonly VITE_FRONTEND_BASE_URL: string;
+    readonly VITE_CDN_BASE_URL: string;
+    readonly VITE_KAKAO_CLIENT_ID: string;
     readonly VITE_KAKAO_MAP_ID: string;
+    readonly VITE_BUSINESS_SERVICE_KEY: string;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,7 +44,7 @@ export default defineConfig(({ mode }) => {
         output: {
           // iOS Safari를 위한 청크 분할 최적화
           manualChunks: {
-            vendor: ["react", "react-dom"],
+            reactCore: ["react", "react-dom"],
             router: ["react-router-dom"]
           },
           // 🔒 파일명 해싱으로 추측 방지

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import react from "@vitejs/plugin-react";
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd());
+  const isProduction = mode === "production";
 
   return {
     plugins: [react()],
@@ -33,8 +34,8 @@ export default defineConfig(({ mode }) => {
     build: {
       outDir: "dist",
       target: "es2015", // iOS Safari 호환성 강화
-      minify: "terser",
-      sourcemap: true, // iOS 디버깅용
+      minify: "esbuild",
+      sourcemap: !isProduction,
       rollupOptions: {
         // SPA 라우팅을 위한 히스토리 API 폴백 지원
         input: {
@@ -43,11 +44,16 @@ export default defineConfig(({ mode }) => {
         output: {
           // iOS Safari를 위한 청크 분할 최적화
           manualChunks: {
-            vendor: ['react', 'react-dom'],
-            router: ['react-router-dom']
-          }
+            vendor: ["react", "react-dom"],
+            router: ["react-router-dom"]
+          },
+          // 🔒 파일명 해싱으로 추측 방지
+          entryFileNames: "assets/[name]-[hash].js",
+          chunkFileNames: "assets/[name]-[hash].js",
+          assetFileNames: "assets/[name]-[hash].[ext]",
         }
-      }
+      },
+      chunkSizeWarningLimit: 1000, // 청크 크기 경고 임계값 증가
     },
     preview: {
       // 빌드된 앱 미리보기에서도 히스토리 API 폴백 적용


### PR DESCRIPTION
## Summary
- Promote the Cloudflare asset-name hotfix from develop to main
- React runtime chunk is now emitted as reactCore instead of vendor
- FE CI now fails if dist output contains /assets/vendor-

## Verification
- PR #22 merged into develop
- develop frontend-ci run 25964082824 passed, including Guard Cloudflare-blocked asset names
- xhigh critic approved the hotfix

## Production symptom fixed
- Current production blocks /assets/vendor-CY5KFkx3.js with Cloudflare 403, preventing React from booting