### PR TITLE
Fix Cloudflare-blocked frontend vendor chunk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,14 @@ jobs:
         timeout-minutes: 10
         run: npm run build
 
+      - name: Guard Cloudflare-blocked asset names
+        run: |
+          set -euo pipefail
+          if grep -R '/assets/vendor-' dist/index.html dist/assets 2>/dev/null; then
+            echo "The deployed Cloudflare zone blocks /assets/vendor-*.js. Rename the chunk before merging."
+            exit 1
+          fi
+
       - name: Typecheck changed files
         timeout-minutes: 5
         run: npm run typecheck:changed

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,7 +44,7 @@ export default defineConfig(({ mode }) => {
         output: {
           // iOS Safari를 위한 청크 분할 최적화
           manualChunks: {
-            vendor: ["react", "react-dom"],
+            reactCore: ["react", "react-dom"],
             router: ["react-router-dom"]
           },
           // 🔒 파일명 해싱으로 추측 방지


### PR DESCRIPTION
## Summary
- Rename the React runtime chunk from vendor to reactCore because production Cloudflare blocks /assets/vendor-*.js
- Add a frontend CI guard that fails if built dist output contains /assets/vendor-

## Verification
- npm run build
- FAIRPLAY_CHECK_BASE=origin/main npm run verify:changed
- xhigh critic approved the develop hotfix; this branch is the same change cherry-picked onto main

## Production symptom
- https://fairplay.rktclgh.site served HTML, main JS, router JS, and /api/events with 200
- /assets/vendor-CY5KFkx3.js returned Cloudflare 403, preventing React from booting