### PR TITLE
Restore home content, chat, and Kakao auth routing

### DIFF
--- a/src/components/chat/ChatRoom.tsx
+++ b/src/components/chat/ChatRoom.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import api from "../../api/axios";
 import { useChatSocket } from "./useChatSocket";
-import { ArrowLeft, Send } from "lucide-react";
+import { Send } from "lucide-react";
 import UserOnlineStatus from "./UserOnlineStatus";
 
 // 메시지 DTO 타입
@@ -24,7 +24,12 @@ type Props = {
     isAiChat?: boolean; // AI 채팅방 여부
 };
 
-export default function ChatRoom({ roomId, onBack, eventTitle, userName, otherUserId, isAdminInquiry, isAiChat }: Props) {
+type ChatRoomSummary = {
+    chatRoomId: number;
+    eventTitle?: string;
+};
+
+export default function ChatRoom({ roomId, eventTitle, userName, otherUserId, isAdminInquiry, isAiChat }: Props) {
     const [messages, setMessages] = useState<ChatMessageDto[]>([]);
     const [input, setInput] = useState("");
     const [myUserId, setMyUserId] = useState<number>(0);
@@ -34,8 +39,6 @@ export default function ChatRoom({ roomId, onBack, eventTitle, userName, otherUs
     );
     const [detectedOtherUserId, setDetectedOtherUserId] = useState<number | null>(null);
     const [isSending, setIsSending] = useState(false); // 전송 중 상태
-    const [pendingMessage, setPendingMessage] = useState<string | null>(null); // 대기 중인 메시지
-    const [lastAiMessageId, setLastAiMessageId] = useState<number | null>(null); // 마지막 AI 메시지 ID 추적
     const [hasMoreMessages, setHasMoreMessages] = useState<boolean>(true); // 더 많은 메시지가 있는지
     const [isLoadingMore, setIsLoadingMore] = useState<boolean>(false); // 추가 메시지 로딩 중
     const [oldestMessageId, setOldestMessageId] = useState<number | null>(null); // 가장 오래된 메시지 ID
@@ -99,8 +102,6 @@ export default function ChatRoom({ roomId, onBack, eventTitle, userName, otherUs
         if (isAiChat && msg.senderId === 999) {
             console.log("🤖 AI 봇 응답 도착! 전송 버튼 활성화 및 즉시 읽음 처리");
             setIsSending(false);
-            setPendingMessage(null);
-            setLastAiMessageId(msg.chatMessageId);
             
             // AI 메시지는 즉시 백엔드로 읽음 처리 요청
             setTimeout(() => markMessagesAsRead(), 100);
@@ -235,7 +236,8 @@ export default function ChatRoom({ roomId, onBack, eventTitle, userName, otherUs
         // 채팅방 정보 가져오기 (제목 설정용)
         if (!eventTitle && !isAdminInquiry) {
             api.get(`/api/chat/rooms`).then(res => {
-                const room = res.data.find((r: any) => r.chatRoomId === roomId);
+                const rooms = Array.isArray(res.data) ? (res.data as ChatRoomSummary[]) : [];
+                const room = rooms.find((r) => r.chatRoomId === roomId);
                 if (room && room.eventTitle) {
                     setRoomTitle(room.eventTitle);
                 }
@@ -290,7 +292,6 @@ export default function ChatRoom({ roomId, onBack, eventTitle, userName, otherUs
         if (isAiChat) {
             console.log("🚀 AI 메시지 전송 시작 - 버튼 비활성화!");
             setIsSending(true);
-            setPendingMessage(message);
         }
         
         send(message);

--- a/src/components/chat/ChatRoom.tsx
+++ b/src/components/chat/ChatRoom.tsx
@@ -190,7 +190,7 @@ export default function ChatRoom({ roomId, onBack, eventTitle, userName, otherUs
     // 새 메시지 수신 시에만 아래로 스크롤 (기존 메시지 로드 시에는 스크롤 안함)
     const [shouldScrollToBottom, setShouldScrollToBottom] = useState(true);
 
-    const { send } = useChatSocket(roomId, handleMessage);
+    const { send } = useChatSocket(roomId, handleMessage, { isAiChat });
 
     // 최초 진입 시 기존 메시지 내역 조회
     useEffect(() => {

--- a/src/components/chat/useChatSocket.ts
+++ b/src/components/chat/useChatSocket.ts
@@ -12,6 +12,29 @@ type ChatMessage = {
   isRead: boolean;
 };
 
+type IncomingChatMessage = Partial<ChatMessage> & {
+  type?: string;
+  content?: string;
+};
+
+const normalizeIncomingMessage = (
+  message: IncomingChatMessage,
+  roomId: number
+): ChatMessage => {
+  if (message.type === "system_error") {
+    return {
+      chatMessageId: -Date.now(),
+      chatRoomId: message.chatRoomId ?? roomId,
+      senderId: 999,
+      content: message.content ?? "AI 응답 생성 중 오류가 발생했습니다.",
+      sentAt: message.sentAt ?? new Date().toISOString(),
+      isRead: true,
+    };
+  }
+
+  return message as ChatMessage;
+};
+
 export function useChatSocket(
   roomId: number,
   onMessage: (msg: ChatMessage) => void,
@@ -168,7 +191,7 @@ export function useChatSocket(
                 topic,
                 (message) => {
                   try {
-                    const parsedMessage = JSON.parse(message.body);
+                    const parsedMessage = normalizeIncomingMessage(JSON.parse(message.body), roomId);
                     console.log(
                       "메시지 수신:",
                       parsedMessage.content,
@@ -262,7 +285,7 @@ export function useChatSocket(
           isAiChat ? `/topic/ai-chat.${roomId}` : `/topic/chat.${roomId}`,
           (message) => {
             try {
-              const parsedMessage = JSON.parse(message.body);
+              const parsedMessage = normalizeIncomingMessage(JSON.parse(message.body), roomId);
               console.log(
                 "메시지 수신:",
                 parsedMessage.content,

--- a/src/components/chat/useChatSocket.ts
+++ b/src/components/chat/useChatSocket.ts
@@ -32,6 +32,41 @@ export function useChatSocket(
   const isMountedRef = useRef(true);
   const initRef = useRef(false);
 
+  const sendMessageInternal = useCallback(async (content: string, stomp: Stomp.Client) => {
+    try {
+      let userId = null;
+      try {
+        const response = await fetch('/api/events/user/role', {
+          credentials: 'include',
+          headers: { 'X-Silent-Auth': 'true' }
+        });
+        if (response.ok) {
+          const userData = await response.json();
+          userId = userData.userId;
+        }
+      } catch (error) {
+        console.error("사용자 ID 조회 실패:", error);
+      }
+
+      const messagePayload = {
+        chatRoomId: roomId,
+        content: content.trim(),
+        senderId: userId || 1,
+        ...(isAiChat ? { provider: 'HERMES' } : {}),
+      };
+
+      console.log("메시지 전송:", content.trim(), "from userId:", userId);
+
+      stomp.send(
+        isAiChat ? "/app/ai-chat.sendMessage" : "/app/chat.sendMessage",
+        {},
+        JSON.stringify(messagePayload)
+      );
+    } catch (error) {
+      console.error("Failed to send message:", error);
+    }
+  }, [roomId, isAiChat]);
+
   useEffect(() => {
     isMountedRef.current = true;
     if (!initRef.current) {
@@ -269,7 +304,7 @@ export function useChatSocket(
         heartbeatIntervalRef.current = null;
       }
     };
-  }, [roomId, onMessage, isAuthenticated, isAiChat]);
+  }, [roomId, onMessage, isAuthenticated, isAiChat, sendMessageInternal]);
   
   useEffect(() => {
     return () => {
@@ -325,41 +360,6 @@ export function useChatSocket(
       }, 100);
     };
   }, []);
-
-  const sendMessageInternal = useCallback(async (content: string, stomp: Stomp.Client) => {
-    try {
-      let userId = null;
-      try {
-        const response = await fetch('/api/events/user/role', {
-          credentials: 'include',
-          headers: { 'X-Silent-Auth': 'true' }
-        });
-        if (response.ok) {
-          const userData = await response.json();
-          userId = userData.userId;
-        }
-      } catch (error) {
-        console.error("사용자 ID 조회 실패:", error);
-      }
-
-      const messagePayload = {
-        chatRoomId: roomId,
-        content: content.trim(),
-        senderId: userId || 1,
-        ...(isAiChat ? { provider: 'HERMES' } : {}),
-      };
-
-      console.log("메시지 전송:", content.trim(), "from userId:", userId);
-
-      stomp.send(
-        isAiChat ? "/app/ai-chat.sendMessage" : "/app/chat.sendMessage",
-        {},
-        JSON.stringify(messagePayload)
-      );
-    } catch (error) {
-      console.error("Failed to send message:", error);
-    }
-  }, [roomId, isAiChat]);
 
   const send = useCallback(
     (content: string) => {

--- a/src/components/chat/useChatSocket.ts
+++ b/src/components/chat/useChatSocket.ts
@@ -14,9 +14,11 @@ type ChatMessage = {
 
 export function useChatSocket(
   roomId: number,
-  onMessage: (msg: ChatMessage) => void
+  onMessage: (msg: ChatMessage) => void,
+  options: { isAiChat?: boolean } = {}
 ) {
   const { isAuthenticated } = useAuth();
+  const isAiChat = Boolean(options.isAiChat);
   const clientRef = useRef<Stomp.Client | null>(null);
   const isConnectedRef = useRef(false);
   const currentRoomIdRef = useRef<number | null>(null);
@@ -126,8 +128,9 @@ export function useChatSocket(
             }, 30000);
 
             if (!subscriptionRef.current) {
+              const topic = isAiChat ? `/topic/ai-chat.${roomId}` : `/topic/chat.${roomId}`;
               subscriptionRef.current = stomp.subscribe(
-                `/topic/chat.${roomId}`,
+                topic,
                 (message) => {
                   try {
                     const parsedMessage = JSON.parse(message.body);
@@ -145,7 +148,7 @@ export function useChatSocket(
                   }
                 }
               );
-              console.log("Subscribed to topic:", `/topic/chat.${roomId}`);
+              console.log("Subscribed to topic:", topic);
             }
 
             const pending = [...pendingMessages.current];
@@ -221,7 +224,7 @@ export function useChatSocket(
       } else if (clientRef.current?.connected && !subscriptionRef.current) {
         console.log(`Subscribing to room ${roomId} on existing connection`);
         subscriptionRef.current = clientRef.current.subscribe(
-          `/topic/chat.${roomId}`,
+          isAiChat ? `/topic/ai-chat.${roomId}` : `/topic/chat.${roomId}`,
           (message) => {
             try {
               const parsedMessage = JSON.parse(message.body);
@@ -239,7 +242,7 @@ export function useChatSocket(
             }
           }
         );
-        console.log("Subscribed to topic:", `/topic/chat.${roomId}`);
+        console.log("Subscribed to topic:", isAiChat ? `/topic/ai-chat.${roomId}` : `/topic/chat.${roomId}`);
       }
     };
 
@@ -266,7 +269,7 @@ export function useChatSocket(
         heartbeatIntervalRef.current = null;
       }
     };
-  }, [roomId, onMessage, isAuthenticated]);
+  }, [roomId, onMessage, isAuthenticated, isAiChat]);
   
   useEffect(() => {
     return () => {
@@ -343,19 +346,20 @@ export function useChatSocket(
         chatRoomId: roomId,
         content: content.trim(),
         senderId: userId || 1,
+        ...(isAiChat ? { provider: 'HERMES' } : {}),
       };
 
       console.log("메시지 전송:", content.trim(), "from userId:", userId);
 
       stomp.send(
-        "/app/chat.sendMessage",
+        isAiChat ? "/app/ai-chat.sendMessage" : "/app/chat.sendMessage",
         {},
         JSON.stringify(messagePayload)
       );
     } catch (error) {
       console.error("Failed to send message:", error);
     }
-  }, [roomId]);
+  }, [roomId, isAiChat]);
 
   const send = useCallback(
     (content: string) => {

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -20,6 +20,8 @@ import type {
   EventSummaryDto
 } from "../services/types/eventType";
 import { useTranslation } from 'react-i18next';
+import type { i18n as I18nInstance } from "i18next";
+import type { Swiper as SwiperInstance } from "swiper";
 import "swiper/css/effect-coverflow";
 import type { HotPick } from "../services/event";
 import NewLoader from "../components/NewLoader";
@@ -30,8 +32,48 @@ const ENABLE_NEW_PICKS = import.meta.env.VITE_ENABLE_NEW_PICKS === "true";
 
 // HMR 테스트 주석 제거
 
+declare global {
+  interface Window {
+    heroSwiper?: SwiperInstance;
+  }
+}
+
+type Translator = (key: string) => string;
+type BannerValue = string | number | boolean | null | undefined;
+type FlexibleBannerResp = BannerResp & {
+  bannerType?: string | null;
+  status?: string | null;
+  event_id?: number | null;
+  image_url?: string | null;
+  link_url?: string | null;
+  start_date?: string | null;
+  end_date?: string | null;
+};
+
+const getHttpErrorInfo = (err: unknown): { status?: number; data?: unknown } => {
+  if (typeof err === "object" && err !== null && "response" in err) {
+    const response = (err as { response?: { status?: number; data?: unknown } }).response;
+    return { status: response?.status, data: response?.data };
+  }
+  return {};
+};
+
+const getBannerValue = (o: FlexibleBannerResp, ...keys: Array<keyof FlexibleBannerResp>): BannerValue => {
+  for (const key of keys) {
+    const value = o[key];
+    if (value != null) return value as BannerValue;
+  }
+  return undefined;
+};
+
+const asString = (value: BannerValue, fallback = ""): string =>
+  typeof value === "string" ? value : fallback;
+
+const asNumber = (value: BannerValue, fallback: number | null = null): number | null =>
+  typeof value === "number" && Number.isFinite(value) ? value : fallback;
+
 // 카테고리 번역 함수
-const translateCategory = (category: string, t: any): string => {
+const translateCategory = (category: string, t: Translator): string => {
   const categoryMap: Record<string, string> = {
     "박람회": "categories.박람회",
     "공연": "categories.공연",
@@ -53,7 +95,7 @@ const categoryColors = {
 };
 
 // 이벤트 제목 선택 함수 (번역 여부에 따라 한글/영문 제목 선택)
-const getEventTitle = (event: EventSummaryDto, i18n: any): string => {
+const getEventTitle = (event: EventSummaryDto, i18n: Pick<I18nInstance, "language">): string => {
   // 현재 언어가 영어이고 영문 제목이 있는 경우 영문 제목 사용
   if (i18n.language === 'en' && event.titleEng && event.titleEng.trim() !== '') {
     return event.titleEng;
@@ -175,6 +217,7 @@ type SearchTopDto = {
 // ★ NEW 픽 응답 (백엔드 /api/banner/new-picks)
 type NewPickDto = {
   id: number;         // = eventId
+  eventId?: number;
   title: string;
   image: string | null;
   date: string | null;
@@ -210,7 +253,7 @@ const fetchNewPicks = async (size = 20): Promise<NewPickDto[]> => {
       const created = getCreated(item) || "";
       const eid =
         Number.isFinite(item.id) ? item.id
-          : Number.isFinite((item as any).eventId) ? (item as any).eventId
+          : Number.isFinite(item.eventId) ? item.eventId
             : NaN;
       return {
         ...item,
@@ -531,8 +574,9 @@ export const Main: React.FC = () => {
         const { data } = await api.get<BannerResp[] | BannerResp>(url, { params });
         const list = Array.isArray(data) ? data : data ? [data] : [];
         if (list.length) return list;
-      } catch (err: any) {
-        console.warn("[HERO] request fail:", url, err?.response?.status, err?.response?.data);
+      } catch (err: unknown) {
+        const { status, data } = getHttpErrorInfo(err);
+        console.warn("[HERO] request fail:", url, status, data);
       }
     }
     return [];
@@ -556,9 +600,9 @@ export const Main: React.FC = () => {
       const raw = await fetchHeroBanners();
       console.log("[HERO] raw count:", raw.length, raw);
 
-      const filtered = raw.filter(r => {
-        const type = asUpper((r as any).bannerTypeCode ?? (r as any).bannerType);
-        const status = asUpper((r as any).statusCode ?? (r as any).status);
+      const filtered = raw.filter((r: FlexibleBannerResp) => {
+        const type = asUpper(r.bannerTypeCode ?? r.bannerType);
+        const status = asUpper(r.statusCode ?? r.status);
         const okType = ["HERO", "MAIN", "HERO_MAIN"].includes(type || "HERO");
         const okStatus = ["ACTIVE", "APPROVED", "PUBLISHED"].includes(status || "ACTIVE");
         return okType && okStatus && isTodayInRange(r.startDate, r.endDate);
@@ -577,28 +621,24 @@ export const Main: React.FC = () => {
         return;
       }
 
-      const get = (o: any, ...keys: string[]) => {
-        for (const k of keys) if (o && o[k] != null) return o[k];
-        return undefined;
-      };
       setPaidAdvertisements(
         filtered
           .map(r => {
-            const eid = get(r, "eventId", "event_id") ?? null;
-            const img = get(r, "imageUrl", "image_url") ?? "/images/FPlogo.png";
-            const rawLink = get(r, "linkUrl", "link_url") ?? "";
+            const eid = asNumber(getBannerValue(r, "eventId", "event_id"));
+            const img = asString(getBannerValue(r, "imageUrl", "image_url"), "/images/FPlogo.png");
+            const rawLink = asString(getBannerValue(r, "linkUrl", "link_url"));
             return {
-              id: get(r, "id"),
+              id: asNumber(getBannerValue(r, "id"), 0) ?? 0,
               eventId: eid,
-              title: get(r, "title") ?? "",
+              title: asString(getBannerValue(r, "title")),
               imageUrl: img,
-              thumbnailUrl: get(r, "smallImageUrl", "smallImageUrl") ?? img,
+              thumbnailUrl: asString(getBannerValue(r, "smallImageUrl"), img),
               // ★ eventId가 있으면 상세로 바로 가는 내부 링크를 만들어 둠
               linkUrl: rawLink || (eid ? `/eventdetail/${eid}` : ""),
-              startDate: get(r, "startDate", "start_date") ?? "",
-              endDate: get(r, "endDate", "end_date") ?? "",
+              startDate: asString(getBannerValue(r, "startDate", "start_date")),
+              endDate: asString(getBannerValue(r, "endDate", "end_date")),
               isActive: true,
-              priority: get(r, "priority") ?? 999,
+              priority: asNumber(getBannerValue(r, "priority"), 999) ?? 999,
             } as PaidAdvertisement;
           })
           .sort((a, b) => a.priority - b.priority)
@@ -700,8 +740,9 @@ setMdPickEventIds(new Set(searchTop.map(s => Number(s.eventId)).filter(Number.is
               setShowNewDeltaBanner(true);
               setTimeout(() => setShowNewDeltaBanner(false), 3500);
             }
-          } catch (err: any) {
-            if (err?.response?.status === 403) {
+          } catch (err: unknown) {
+            const { status } = getHttpErrorInfo(err);
+            if (status === 403) {
               console.warn("[NEW-PICKS] 403: 인증/권한 이슈. NEW 배지는 숨김 처리.");
             } else {
               console.warn("[NEW-PICKS] 로드 실패:", err);
@@ -714,7 +755,7 @@ setMdPickEventIds(new Set(searchTop.map(s => Number(s.eventId)).filter(Number.is
         }
         // 2) 기본 리스트
         const eventsData = await eventAPI.getEventList({ size: 30, includeHidden: false });
-        let baseEvents = eventsData?.events ?? [];
+        const baseEvents = eventsData?.events ?? [];
 
         // 제목으로도 보강
         for (const s of searchTop) {
@@ -833,43 +874,6 @@ setMdPickEventIds(new Set(searchTop.map(s => Number(s.eventId)).filter(Number.is
     const dup = keys.filter((k, i) => keys.indexOf(k) !== i);
     if (dup.length) console.warn('[HOT DUP KEYS]', dup, keys);
   }, [hotPicks]);
-
-  const todayKey = dayjs().format("YYYY-MM-DD");
-
-  function getMdPickIdsForToday(): Set<number> {
-    try {
-      if (typeof window === "undefined") return new Set<number>();
-      const raw = localStorage.getItem(`mdpick:${todayKey}`);
-      const arr = raw ? JSON.parse(raw) : null;
-      if (!Array.isArray(arr)) return new Set<number>();
-      return new Set<number>(
-        arr
-          .slice(0, 2)
-          .map((v: unknown) => Number(v))
-          .filter((n) => Number.isFinite(n))
-      );
-    } catch {
-      return new Set<number>();
-    }
-  }
-
-  function getMdPickTitlesForToday(): Set<string> {
-    try {
-      if (typeof window === "undefined") return new Set<string>();
-      const raw = localStorage.getItem(`mdpick_titles:${todayKey}`);
-      const arr = raw ? JSON.parse(raw) : null;
-      if (!Array.isArray(arr)) return new Set<string>();
-      return new Set<string>(arr.slice(0, 2).map((v: unknown) => String(v)));
-    } catch {
-      return new Set<string>();
-    }
-  }
-  const normalize = (s: string) => (s || '').toLowerCase().replace(/[\s\-_/·・‧ㆍ]/g, '');
-
-  const mdPickIds = getMdPickIdsForToday();
-  const mdPickTitles = getMdPickTitlesForToday();
-  const mdPickTitleNorms = new Set(Array.from(mdPickTitles).map(normalize));
-
 
   const isEventMdPick = (e: EventSummaryDto) => mdPickEventIds.has(e.id);
   const hasMdPickInCurrentList = events.some(e => mdPickEventIds.has(e.id));
@@ -1101,7 +1105,7 @@ setMdPickEventIds(new Set(searchTop.map(s => Number(s.eventId)).filter(Number.is
             autoplay={heroLoop ? { delay: 4000 } : false}
             loop={heroLoop}
             className="w-full h-full"
-            onSwiper={(swiper) => { (window as any).heroSwiper = swiper; }}
+            onSwiper={(swiper) => { window.heroSwiper = swiper; }}
           >
 
             {paidAdvertisements.map((ad, index) => (
@@ -1129,8 +1133,8 @@ setMdPickEventIds(new Set(searchTop.map(s => Number(s.eventId)).filter(Number.is
                   <div key={`hero-thumb-${ad.id ?? 'na'}-${index}`}
                     className="w-12 h-16 md:w-16 md:h-20 cursor-pointer transition-all duration-300 hover:scale-110 opacity-60 hover:opacity-100"
                     onMouseEnter={() => {
-                      if (heroLoop && (window as any).heroSwiper) {
-                        (window as any).heroSwiper.slideToLoop(index);
+                      if (heroLoop && window.heroSwiper) {
+                        window.heroSwiper.slideToLoop(index);
                       }
                     }}
                   >

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -776,7 +776,7 @@ setMdPickEventIds(new Set(searchTop.map(s => Number(s.eventId)).filter(Number.is
             try {
               const d = await eventAPI.getEventDetail(id);
               extras.push({
-                id: d.eventId,
+                id: d.eventId ?? id,
                 title: d.titleKr,
                 thumbnailUrl: d.thumbnailUrl,
                 startDate: d.startDate,

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -181,6 +181,7 @@ type NewPickDto = {
   location: string | null;
   category: string | null;
   createdAt: string;   // ISO string "2025-08-20T13:25:30"
+  created_at?: string;
   isNew?: boolean;
 };
 
@@ -478,11 +479,10 @@ export const Main: React.FC = () => {
         page?: number;
         size?: number;
       } = {
+        includeHidden: false,
         page: 0,
         size: 20,
       };
-
-      params.includeHidden = false;
 
       if (selectedCategory !== t('categories.all') && selectedCategory !== "전체") {
         params.mainCategoryId = mapMainCategoryToId(selectedCategory);
@@ -521,10 +521,10 @@ export const Main: React.FC = () => {
 
 
   const fetchHeroBanners = async (): Promise<BannerResp[]> => {
-    const tries = [
+    const tries: Array<{ url: string; params?: Record<string, string> }> = [
       { url: "/api/banners/hero/active" },
       { url: "/api/banners", params: { type: "HERO", status: "ACTIVE" } },
-    ] as const;
+    ];
 
     for (const { url, params } of tries) {
       try {
@@ -735,14 +735,14 @@ setMdPickEventIds(new Set(searchTop.map(s => Number(s.eventId)).filter(Number.is
             try {
               const d = await eventAPI.getEventDetail(id);
               extras.push({
-                id: d.id,
-                title: d.title,
+                id: d.eventId,
+                title: d.titleKr,
                 thumbnailUrl: d.thumbnailUrl,
                 startDate: d.startDate,
                 endDate: d.endDate,
-                location: d.location,
+                location: d.placeName || d.address,
                 mainCategory: d.mainCategory,
-                minPrice: d.minPrice,
+                minPrice: 0,
               } as EventSummaryDto);
             } catch (e) {
               console.warn("MD PICK 개별 조회 실패:", id, e);
@@ -776,7 +776,10 @@ setMdPickEventIds(new Set(searchTop.map(s => Number(s.eventId)).filter(Number.is
 
             // 현재 진행 중이거나 예정된 이벤트 중 상위 10개 선택
             const hotPickCandidates = baseEvents
-              .filter(event => event.eventStatusCode === 'ONGOING' || event.eventStatusCode === 'UPCOMING')
+              .filter(event => {
+                const statusCode = event.eventStatusCode ?? event.statusCode;
+                return statusCode === 'ONGOING' || statusCode === 'UPCOMING';
+              })
               .slice(0, 10)
               .map(event => ({
                 id: event.id,

--- a/src/pages/user_auth/KakaoCallback.tsx
+++ b/src/pages/user_auth/KakaoCallback.tsx
@@ -27,7 +27,7 @@ const KakaoCallback = () => {
                 console.log('User Agent:', navigator.userAgent);
                 console.log('Current URL:', window.location.href);
                 
-                const response = await api.post('/api/auth/kakao', { code }); // POST JSON!
+                await api.post('/api/auth/kakao', { code }); // POST JSON!
 
                 // HTTP-only 쿠키 방식에서는 토큰을 localStorage에 저장하지 않음
                 toast.success('카카오 로그인에 성공했습니다!');
@@ -58,21 +58,25 @@ const KakaoCallback = () => {
                     console.error("Role API 호출 실패:", error);
                     navigate("/"); // 기본적으로 메인 페이지로
                 }
-            } catch (error: any) {
+            } catch (error: unknown) {
+                const responseError =
+                    typeof error === 'object' && error !== null && 'response' in error
+                        ? (error as { response?: { status?: number; data?: unknown; headers?: unknown }; config?: unknown; message?: string; name?: string })
+                        : {};
                 console.error('카카오 로그인 에러 상세:', {
-                    status: error?.response?.status,
-                    data: error?.response?.data,
-                    headers: error?.response?.headers,
-                    config: error?.config,
-                    message: error?.message,
-                    name: error?.name
+                    status: responseError.response?.status,
+                    data: responseError.response?.data,
+                    headers: responseError.response?.headers,
+                    config: responseError.config,
+                    message: responseError.message,
+                    name: responseError.name
                 });
                 toast.error('카카오 로그인에 실패했습니다.');
                 navigate('/login');
             }
         };
         handleKakaoLogin(code);
-    }, [location, navigate]);
+    }, [location, navigate, login]);
 
     return (
         <div className="flex justify-center items-center h-screen">

--- a/src/pages/user_auth/LoginPage.tsx
+++ b/src/pages/user_auth/LoginPage.tsx
@@ -10,6 +10,7 @@ import { setCachedRoleCode } from "../../utils/role";
 import { useTranslation } from "react-i18next";
 import { useScrollToTop } from "../../hooks/useScrollToTop";
 import { useAuth } from "../../context/AuthContext";
+import { buildKakaoAuthorizeUrl } from "../../utils/kakaoAuth";
 
 export const LoginPage = () => {
     useScrollToTop();
@@ -29,7 +30,7 @@ export const LoginPage = () => {
         if (!isLoginEnabled) return;
         setLoading(true);
         try {
-            const res = await api.post("/api/auth/login", {
+            await api.post("/api/auth/login", {
                 email,
                 password
             });
@@ -95,22 +96,15 @@ export const LoginPage = () => {
     };
 
     const handleKakaoLogin = () => {
-        const KAKAO_CLIENT_ID = import.meta.env.VITE_KAKAO_CLIENT_ID;
-        // 운영 환경에서는 현재 도메인 사용, 개발 환경에서는 env 값 사용
-        const currentOrigin = window.location.origin;
-        const KAKAO_REDIRECT_URI = currentOrigin.includes('localhost')
-            ? `${import.meta.env.VITE_FRONTEND_BASE_URL}/auth/kakao/callback`
-            : `${currentOrigin}/auth/kakao/callback`;
-
-        if (!KAKAO_CLIENT_ID) {
+        const kakaoAuth = buildKakaoAuthorizeUrl();
+        if (!kakaoAuth) {
             toast.error(t('auth.kakaoNotConfigured'));
             console.error("VITE_KAKAO_CLIENT_ID is not set in .env file");
             return;
         }
 
-        console.log('카카오 로그인 redirect URI:', KAKAO_REDIRECT_URI);
-        const kakaoURL = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_CLIENT_ID}&redirect_uri=${KAKAO_REDIRECT_URI}&response_type=code`;
-        window.location.href = kakaoURL;
+        console.log('카카오 로그인 redirect URI:', kakaoAuth.redirectUri);
+        window.location.href = kakaoAuth.url;
     };
 
     return (

--- a/src/pages/user_auth/SignUpPage.tsx
+++ b/src/pages/user_auth/SignUpPage.tsx
@@ -9,10 +9,7 @@ import api from "../../api/axios";
 import { toast } from "react-toastify";
 import { Link, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-
-// .env 환경변수 적용
-const KAKAO_CLIENT_ID = import.meta.env.VITE_KAKAO_CLIENT_ID;
-const REDIRECT_URI = `${import.meta.env.VITE_FRONTEND_BASE_URL}/auth/kakao/callback`;
+import { buildKakaoAuthorizeUrl } from "../../utils/kakaoAuth";
 
 export const SignUpPage = () => {
     const { t } = useTranslation();
@@ -155,7 +152,7 @@ export const SignUpPage = () => {
             toast.info(t('auth.verificationCodeSent'));
             setVerificationSent(true);
             setEmailVerificationTimer(30);
-        } catch (error) {
+        } catch {
             toast.error(t('auth.verificationCodeSendFailed'));
         } finally {
             setIsSendingVerification(false);
@@ -171,7 +168,9 @@ export const SignUpPage = () => {
             await api.post("/api/email/verify-code", { email, code: verificationCode });
             toast.success(t('auth.verificationSuccess2'));
             setVerified(true);
-        } catch { }
+        } catch {
+            toast.error(t('auth.verificationFailed'));
+        }
     };
 
     const handleSignUp = async () => {
@@ -190,13 +189,20 @@ export const SignUpPage = () => {
             });
             toast.success(t('auth.signupSuccess2'));
             navigate("/login");
-        } catch { }
+        } catch {
+            toast.error(t('auth.signupError'));
+        }
     };
 
     // 카카오 연동용 회원가입(로그인) 버튼
     const handleKakaoSignUp = () => {
-        window.location.href =
-            `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=code`;
+        const kakaoAuth = buildKakaoAuthorizeUrl();
+        if (!kakaoAuth) {
+            toast.error(t('auth.kakaoNotConfigured'));
+            return;
+        }
+
+        window.location.href = kakaoAuth.url;
     };
 
     const isSignUpEnabled =

--- a/src/services/event.ts
+++ b/src/services/event.ts
@@ -109,7 +109,7 @@ export const eventAPI = {
                 totalPages: 0,
                 totalElements: 0,
                 currentPage: 0,
-                pageSize: params.size || 20
+                pageSize: params?.size || 20
             };
         }
     },

--- a/src/services/event.ts
+++ b/src/services/event.ts
@@ -5,11 +5,10 @@ import type {
     EventDetailRequestDto,
     EventDetailResponseDto,
     EventDetailModificationRequestDto,
-    ExternalLinkRequestDto,
     EventSummaryResponseDto,
     EventApplyRequestDto,
     EventApplyResponseDto,
-    Page, PageResponse, EventApplyListItem, EventApplyDetail
+    PageResponse, EventApplyListItem, EventApplyDetail
 } from './types/eventType';
 
 export interface HotPick {
@@ -21,6 +20,21 @@ export interface HotPick {
   image: string;
 }
 
+type HttpError = {
+  response?: {
+    status?: number;
+    data?: unknown;
+  };
+};
+
+const getHttpErrorInfo = (err: unknown): { status?: number; data?: unknown } => {
+  if (typeof err === 'object' && err !== null && 'response' in err) {
+    const response = (err as HttpError).response;
+    return { status: response?.status, data: response?.data };
+  }
+  return {};
+};
+
 export const eventAPI = {
 
    async getHotPicks({ size = 10 }: { size?: number } = {}): Promise<HotPick[]> {
@@ -30,10 +44,13 @@ export const eventAPI = {
       ["/api/banner/hot-picks",  { size }],
     ] as const;
 
-    const parse = (data: any): HotPick[] => {
-      if (Array.isArray(data)) return data;
-      if (Array.isArray(data?.items))   return data.items;
-      if (Array.isArray(data?.content)) return data.content;
+    const parse = (data: unknown): HotPick[] => {
+      if (Array.isArray(data)) return data as HotPick[];
+      if (typeof data === 'object' && data !== null) {
+        const envelope = data as { items?: unknown; content?: unknown };
+        if (Array.isArray(envelope.items)) return envelope.items as HotPick[];
+        if (Array.isArray(envelope.content)) return envelope.content as HotPick[];
+      }
       return [];
     };
 
@@ -41,10 +58,10 @@ export const eventAPI = {
       try {
         const { data } = await api.get(url, { params });
         return parse(data);
-      } catch (err: any) {
-        const status = err?.response?.status;
+      } catch (err: unknown) {
+        const { status, data } = getHttpErrorInfo(err);
         if (status === 404 || status === 405) continue; // 엔드포인트 없을 때만 폴백
-        console.warn("[HOT-PICKS] request failed:", url, status, err?.response?.data);
+        console.warn("[HOT-PICKS] request failed:", url, status, data);
         break;
       }
     }
@@ -152,7 +169,7 @@ export const eventAPI = {
      * @param {Object} modificationData - EventDetailModificationRequestDto 형식
      * @returns 생성된 수정 요청 정보
      */
-    createEventModificationRequest: async (eventId: number, data: EventDetailModificationRequestDto): Promise<any> => {
+    createEventModificationRequest: async (eventId: number, data: EventDetailModificationRequestDto): Promise<unknown> => {
         const res = await api.post(`/api/events/${eventId}/modification-request`, data);
         return res.data;
     },

--- a/src/services/types/eventType.ts
+++ b/src/services/types/eventType.ts
@@ -39,14 +39,17 @@ export interface EventSummaryDto {
     thumbnailUrl: string;
     region: string;
     eventStatusCode?: string; // 행사 상태 코드 추가
+    statusCode?: string; // 행사 목록 API 응답 상태 코드
 }
 
 export interface EventSummaryResponseDto {
     message?: string;
     events: EventSummaryDto[];
-    pageable: any; // 필요시 타입 지정
+    pageable?: any; // 필요시 타입 지정
     totalElements: number;
     totalPages: number;
+    currentPage?: number;
+    pageSize?: number;
 }
 
 // EventDetailRequestDto: 행사 상세 등록 요청

--- a/src/services/types/eventType.ts
+++ b/src/services/types/eventType.ts
@@ -45,7 +45,7 @@ export interface EventSummaryDto {
 export interface EventSummaryResponseDto {
     message?: string;
     events: EventSummaryDto[];
-    pageable?: any; // 필요시 타입 지정
+    pageable?: unknown; // 필요시 타입 지정
     totalElements: number;
     totalPages: number;
     currentPage?: number;
@@ -419,8 +419,8 @@ export interface EventVersionComparisonDto {
     snapshot2: EventSnapshotDto;
     fieldDifferences: Record<string, {
         displayName: string;
-        oldValue: any;
-        newValue: any;
+        oldValue: unknown;
+        newValue: unknown;
         changeType: 'added' | 'removed' | 'modified';
     }>;
 }

--- a/src/utils/kakaoAuth.ts
+++ b/src/utils/kakaoAuth.ts
@@ -4,12 +4,8 @@ const KAKAO_CALLBACK_PATH = "/auth/kakao/callback";
 const stripTrailingSlash = (value: string) => value.replace(/\/+$/, "");
 
 export const getKakaoRedirectUri = (): string => {
-  const currentOrigin = window.location.origin;
   const configuredFrontendBaseUrl = import.meta.env.VITE_FRONTEND_BASE_URL?.trim();
-  const baseUrl =
-    currentOrigin.includes("localhost") && configuredFrontendBaseUrl
-      ? configuredFrontendBaseUrl
-      : currentOrigin;
+  const baseUrl = configuredFrontendBaseUrl || window.location.origin;
 
   return `${stripTrailingSlash(baseUrl)}${KAKAO_CALLBACK_PATH}`;
 };

--- a/src/utils/kakaoAuth.ts
+++ b/src/utils/kakaoAuth.ts
@@ -1,0 +1,32 @@
+const KAKAO_AUTHORIZE_URL = "https://kauth.kakao.com/oauth/authorize";
+const KAKAO_CALLBACK_PATH = "/auth/kakao/callback";
+
+const stripTrailingSlash = (value: string) => value.replace(/\/+$/, "");
+
+export const getKakaoRedirectUri = (): string => {
+  const currentOrigin = window.location.origin;
+  const configuredFrontendBaseUrl = import.meta.env.VITE_FRONTEND_BASE_URL?.trim();
+  const baseUrl =
+    currentOrigin.includes("localhost") && configuredFrontendBaseUrl
+      ? configuredFrontendBaseUrl
+      : currentOrigin;
+
+  return `${stripTrailingSlash(baseUrl)}${KAKAO_CALLBACK_PATH}`;
+};
+
+export const buildKakaoAuthorizeUrl = (): { url: string; redirectUri: string } | null => {
+  const clientId = import.meta.env.VITE_KAKAO_CLIENT_ID?.trim();
+  if (!clientId) return null;
+
+  const redirectUri = getKakaoRedirectUri();
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: "code",
+  });
+
+  return {
+    url: `${KAKAO_AUTHORIZE_URL}?${params.toString()}`,
+    redirectUri,
+  };
+};


### PR DESCRIPTION
## Summary
- accept the event list API's statusCode field in the home-page hot-picks fallback
- keep restored upcoming/ongoing events visible when reservation-ranked hot picks are empty

## Verification
- npm run build
- npm run lint still fails on pre-existing repository-wide ESLint errors unrelated to this change

## Notes
- Public production currently returns /api/events with restored content, but /api/events/hot-picks can legitimately be empty until reservation data exists.
