### PR TITLE
P0-03 결제 완료 계약 정합성 보강

### DIFF
--- a/src/pages/PaymentTest.tsx
+++ b/src/pages/PaymentTest.tsx
@@ -1,33 +1,6 @@
 import { useEffect, useState } from "react";
 import api from "../api/axios";
-
-declare global {
-    interface Window {
-        IMP?: {
-            init: (code: string) => void;
-            request_pay: (
-                param: {
-                    pg: string;
-                    pay_method: string;
-                    merchant_uid: string;
-                    name: string;
-                    amount: number;
-                    buyer_email: string;
-                    buyer_name: string;
-                },
-                cb: (rsp: IamportResponse) => void
-            ) => void;
-        };
-    }
-}
-
-interface IamportResponse {
-    success: boolean;
-    merchant_uid: string;
-    imp_uid?: string;
-    paid_amount?: number;
-    error_msg?: string;
-}
+import paymentService from "../services/paymentService";
 
 interface PaymentResponse {
     paymentId: number;
@@ -63,51 +36,78 @@ export default function PaymentTest(): JSX.Element {
 
     const onClickPayment = async () => {
         setLoading(true);
-        const { IMP } = window;
-        if (!IMP) {
-            alert("포트원 SDK 로딩 실패");
-            return;
-        }
-
-        IMP.init(IMP_CODE);
-        // 1. 결제 준비 (DB에 결제 정보 미리 등록)
-        const requestResponse = await api.post<PaymentResponse>("/api/payments/request", {
-            targetId: 2,
-            amount: 100,
-            eventId: 1,
-            quantity: 2,
-            price: 50,
-            targetType: "RESERVATION"
-        });
-
-        // 2. 결제 요청
-        IMP.request_pay(
-            {
-                pg: "uplus",
-                pay_method: "card",
-                merchant_uid: requestResponse.data.merchantUid,
-                name: "공연 티켓 결제",
-                amount: 100,
-                buyer_email: user.email,
-                buyer_name: user.name
-            },
-            async (rsp) => {
-                if (rsp.success) {
-                    // 3. 결제 검증 (백엔드에서 imp_uid로 포트원 검증)
-                    await api.post("/api/payments/complete", {
-                        impUid: rsp.imp_uid,
-                        merchantUid: rsp.merchant_uid,
-                        paymentId: requestResponse.data.paymentId
-
-                    });
-                    alert("결제 성공!");
-                    setLoading(false);
-                } else {
-                    alert("결제 실패: " + rsp.error_msg);
-                    setLoading(false);
-                }
+        try {
+            const { IMP } = window;
+            if (!IMP) {
+                alert("포트원 SDK 로딩 실패");
+                setLoading(false);
+                return;
             }
-        );
+
+            const eventId = 1;
+            const scheduleId = 1;
+            const ticketId = 2;
+            const quantity = 2;
+            const price = 50;
+            const amount = quantity * price;
+            const paymentTargetType = "RESERVATION";
+            const merchantUid = await paymentService.generateMerchantUid(paymentTargetType);
+
+            IMP.init(IMP_CODE);
+            // 1. 결제 준비 (DB에 결제 정보 미리 등록)
+            await paymentService.savePaymentRequest({
+                eventId,
+                paymentTargetType,
+                quantity,
+                price,
+                amount,
+                merchantUid,
+                pgProvider: "uplus",
+                scheduleId,
+                ticketId
+            });
+
+            // 2. 결제 요청
+            IMP.request_pay(
+                {
+                    pg: "uplus",
+                    pay_method: "card",
+                    merchant_uid: merchantUid,
+                    name: "공연 티켓 결제",
+                    amount,
+                    buyer_email: user.email,
+                    buyer_name: user.name
+                },
+                async (rsp) => {
+                    if (rsp.success) {
+                        if (!rsp.imp_uid) {
+                            alert("결제 승인번호를 확인할 수 없습니다.");
+                            setLoading(false);
+                            return;
+                        }
+
+                        // 3. 결제 검증 (백엔드에서 imp_uid로 포트원 검증)
+                        await paymentService.completePayment({
+                            impUid: rsp.imp_uid,
+                            merchantUid: rsp.merchant_uid,
+                            amount: rsp.paid_amount ?? amount,
+                            applyNum: rsp.apply_num,
+                            scheduleId,
+                            ticketId
+                        });
+                        alert("결제 성공!");
+                        setLoading(false);
+                    } else {
+                        alert("결제 실패: " + rsp.error_msg);
+                        setLoading(false);
+                    }
+                }
+            );
+        } catch (error) {
+            console.error("결제 테스트 실패:", error);
+            alert("결제 요청에 실패했습니다.");
+            setLoading(false);
+        }
     };
 
 
@@ -126,7 +126,7 @@ export default function PaymentTest(): JSX.Element {
                 reason: '테스트 결제 환불1'
             });
             alert("환불 요청이 성공적으로 접수되었습니다.");
-        } catch (error) {
+        } catch {
             alert("환불 요청에 실패했습니다.");
         } finally {
             setLoading(false);
@@ -140,7 +140,7 @@ export default function PaymentTest(): JSX.Element {
 
             await api.post<PaymentResponse>("/api/refunds/" + refundId + "/approve");
             alert("환불이 승인되었습니다.");
-        } catch (error) {
+        } catch {
             alert("환불 승인에 실패했습니다.");
         } finally {
             setLoading(false);

--- a/src/pages/user_event/TicketReservation.tsx
+++ b/src/pages/user_event/TicketReservation.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { TopNav } from "../../components/TopNav";
 import { toast } from "react-toastify";
@@ -65,15 +65,6 @@ interface TicketReservationForm {
     paymentMethod: string;
 }
 
-interface StoredReservationForm {
-    quantity?: number;
-}
-
-interface StoredSelectedTicket {
-    ticketId?: number;
-    price?: number;
-}
-
 const PENDING_PAYMENT_KEYS = [
     'pending_imp_uid',
     'pending_merchant_uid',
@@ -81,8 +72,7 @@ const PENDING_PAYMENT_KEYS = [
     'pending_schedule_id',
     'pending_ticket_id',
     'pending_amount',
-    'ticketReservationForm',
-    'selectedTicket'
+    'pending_quantity'
 ];
 
 const parseStoredNumber = (value: string | null): number | null => {
@@ -91,19 +81,21 @@ const parseStoredNumber = (value: string | null): number | null => {
     return Number.isFinite(parsed) ? parsed : null;
 };
 
-const readStoredObject = <T extends object>(key: string): Partial<T> => {
-    try {
-        const value = localStorage.getItem(key);
-        if (!value) return {};
-        const parsed: unknown = JSON.parse(value);
-        return parsed && typeof parsed === 'object' ? parsed as Partial<T> : {};
-    } catch {
-        return {};
-    }
+const getPendingPaymentItem = (key: string): string | null => {
+    return sessionStorage.getItem(key) ?? localStorage.getItem(key);
+};
+
+const setPendingPaymentItem = (key: string, value: string) => {
+    sessionStorage.setItem(key, value);
 };
 
 const clearPendingPaymentStorage = () => {
-    PENDING_PAYMENT_KEYS.forEach(key => localStorage.removeItem(key));
+    PENDING_PAYMENT_KEYS.forEach(key => {
+        sessionStorage.removeItem(key);
+        localStorage.removeItem(key);
+    });
+    localStorage.removeItem('ticketReservationForm');
+    localStorage.removeItem('selectedTicket');
 };
 
 export const TicketReservation = () => {
@@ -155,85 +147,159 @@ export const TicketReservation = () => {
     // 사용 가능한 티켓 옵션을 백엔드에서 가져온 데이터로 사용
     const ticketReservationOptions = availableTickets;
 
-    // PG사 중간 페이지 감지 및 리다이렉션 (전역 감지)
-    useEffect(() => {
-        const handlePGRedirect = () => {
-            const currentUrl = window.location.href;
-            const pgUrls = [
-                'service.iamport.kr',
-                'm_uplus_payments',
-                'authenticated',
-                'lgdacom',
-                'lguplus',
-                'inicis',
-                'kcp',
-                'toss'
-            ];
+    // 모바일 결제 성공 후 처리 함수
+    const handleMobilePaymentSuccess = useCallback(async (impUid: string, merchantUid: string) => {
+        // 재미있는 메시지들
+        const funMessages = [
+            '박람회를 지배하는 중...',
+            '공연을 나의 것으로 만드는 중...',
+            '축제의 주인공이 되는 중...',
+            '티켓을 황금으로 변환하는 중...',
+            '최고의 자리를 예약하는 중...'
+        ];
 
-            // PG사 URL 감지
-            const isPGPage = pgUrls.some(pgUrl => currentUrl.includes(pgUrl));
+        let messageIndex = 0;
+        setPaymentSuccess(false);
+        setPaymentStep(funMessages[messageIndex]);
 
-            if (isPGPage) {
-                console.log('PG사 중간 페이지 감지:', currentUrl);
+        // 메시지 로테이션 인터벌
+        const messageInterval = setInterval(() => {
+            messageIndex = (messageIndex + 1) % funMessages.length;
+            setPaymentStep(funMessages[messageIndex]);
+        }, 1500);
 
-                // 모든 방법으로 결제 정보 추출 시도
-                const urlParams = new URLSearchParams(window.location.search);
-                const impUid = urlParams.get('imp_uid') ||
-                    urlParams.get('IMP_UID') ||
-                    localStorage.getItem('pending_imp_uid');
+        try {
+            console.log('모바일 결제 완료 처리 시작:', { impUid, merchantUid });
 
-                const merchantUid = urlParams.get('merchant_uid') ||
-                    urlParams.get('LGD_OID') ||
-                    localStorage.getItem('pending_merchant_uid');
+            const mobileScheduleId = scheduleId ?? parseStoredNumber(getPendingPaymentItem('pending_schedule_id'));
+            const mobileTicketId =
+                parseStoredNumber(searchParams.get('ticketId')) ??
+                parseStoredNumber(getPendingPaymentItem('pending_ticket_id'));
+            const mobileAmount = parseStoredNumber(getPendingPaymentItem('pending_amount'));
+            const mobileQuantity = parseStoredNumber(getPendingPaymentItem('pending_quantity'));
 
-                const savedEventId = localStorage.getItem('pending_event_id') || eventId;
-                const savedScheduleId = localStorage.getItem('pending_schedule_id') || scheduleId;
+            if (!mobileScheduleId || !mobileTicketId || mobileAmount === null || mobileQuantity === null) {
+                throw new Error('결제 완료에 필요한 예약 정보가 없습니다. 다시 예매를 진행해주세요.');
+            }
 
-                console.log('추출된 결제 정보:', {
-                    impUid, merchantUid, savedEventId, savedScheduleId,
-                    currentUrl, urlParams: Object.fromEntries(urlParams)
+            // 1. 결제 완료 처리 API 호출
+            const completeResult = await paymentService.completePayment({
+                merchantUid: merchantUid,
+                impUid: impUid,
+                amount: mobileAmount,
+                scheduleId: mobileScheduleId,
+                ticketId: mobileTicketId
+            });
+            console.log('결제 완료 처리 성공:', completeResult);
+
+            const reservationData = {
+                scheduleId: mobileScheduleId,
+                ticketId: mobileTicketId,
+                quantity: mobileQuantity,
+                totalAmount: mobileAmount
+            };
+
+            // 예약은 결제 완료 시 자동으로 생성됨 (PaymentService에서 처리)
+            console.log('모바일 결제 완료:', { completeResult, reservationData });
+
+            // 결제 성공 시 저장소 정리
+            clearPendingPaymentStorage();
+
+            // 메시지 로테이션 중지
+            clearInterval(messageInterval);
+            setPaymentStep('티켓 발급 완료!');
+            setPaymentSuccess(true);
+
+            // PC와 동일하게 2.5초 후 이동 (토스트 알림 제거)
+            setTimeout(() => {
+                navigate('/mypage/reservation');
+            }, 2500);
+
+            // URL 정리
+            const newUrl = new URL(window.location.href);
+            newUrl.searchParams.delete('imp_uid');
+            newUrl.searchParams.delete('merchant_uid');
+            newUrl.searchParams.delete('imp_success');
+            window.history.replaceState({}, '', newUrl);
+
+        } catch (error) {
+            console.error('모바일 결제 완료 처리 오류:', error);
+            // 메시지 로테이션 중지
+            clearInterval(messageInterval);
+            setPaymentStep('결제 실패');
+
+            // 모바일 결제 실패 시 백엔드 락도 해제
+            try {
+                await authManager.authenticatedFetch('/api/payments/status/clear', {
+                    method: 'POST'
                 });
+                console.log('백엔드 결제 락 해제 완료');
+            } catch (clearError) {
+                console.warn('백엔드 결제 락 해제 실패:', clearError);
+            }
 
-                // 일정 시간 후 강제 리다이렉션 (결제 정보가 없어도)
-                const forceRedirect = () => {
-                    if (savedEventId && savedScheduleId) {
-                        const redirectUrl = `/ticketreservation/${savedEventId}/${savedScheduleId}?imp_success=pending&force_redirect=true`;
-                        console.log('강제 리다이렉션:', redirectUrl);
-                        window.location.href = redirectUrl;
-                    }
-                };
-
-                if (impUid && merchantUid && savedEventId && savedScheduleId) {
-                    // 결제 완료 처리 페이지로 리다이렉션
-                    const redirectUrl = `/ticketreservation/${savedEventId}/${savedScheduleId}?imp_success=true&imp_uid=${impUid}&merchant_uid=${merchantUid}`;
-                    console.log('PG사 중간 페이지에서 결제 완료 페이지로 리다이렉션:', redirectUrl);
-                    window.location.href = redirectUrl;
+            // PC와 동일한 상세 에러 메시지 처리
+            let errorMessage = '결제 완료 처리 중 오류가 발생했습니다.';
+            if (error instanceof Error) {
+                if (error.message.includes('network') || error.message.includes('fetch')) {
+                    errorMessage = '네트워크 오류가 발생했습니다. 인터넷 연결을 확인해주세요.';
                 } else {
-                    // 3초 후 강제 리다이렉션
-                    console.log('결제 정보 부족, 3초 후 강제 리다이렉션');
-                    setTimeout(forceRedirect, 3000);
+                    errorMessage = error.message;
                 }
             }
-        };
 
-        // 즉시 체크
-        handlePGRedirect();
+            toast.error(errorMessage);
 
-        // 주기적 체크 (1초마다)
-        const intervalId = setInterval(handlePGRedirect, 1000);
+            clearPendingPaymentStorage();
 
-        // URL 변경 감지
-        const handleUrlChange = () => {
-            setTimeout(handlePGRedirect, 100);
-        };
+            // PC와 동일하게 3초 후 상태 초기화
+            setTimeout(() => {
+                setPaymentStep('');
+                setPaymentSuccess(false);
+            }, 3000);
+        } finally {
+            // 메시지 로테이션 정리 (에러가 발생하더라도 인터벌 정리)
+            clearInterval(messageInterval);
+            // PC와 동일한 상태 초기화
+            setIsProcessing(false);
+        }
+    }, [navigate, scheduleId, searchParams]);
 
-        window.addEventListener('popstate', handleUrlChange);
+    // 회차별 티켓 로드 함수
+    const loadScheduleTickets = useCallback(async (scheduleId: number) => {
+        try {
+            const response = await authManager.authenticatedFetch(`/api/events/${eventId}/schedule/${scheduleId}/tickets`);
 
-        return () => {
-            clearInterval(intervalId);
-            window.removeEventListener('popstate', handleUrlChange);
-        };
-    }, [eventId, scheduleId]);
+            if (!response.ok) {
+                throw new Error(`회차별 티켓 조회 실패: ${response.status}`);
+            }
+
+            const ticketList = await response.json() as ScheduleTicketApiResponse[];
+            console.log('회차별 티켓 목록:', ticketList);
+
+            // 회차별 티켓 정보
+            const formattedTickets = ticketList.map((ticket) => ({
+                ticketId: ticket.ticketId,
+                name: ticket.name,
+                price: ticket.price || 0,
+                maxPurchase: ticket.maxPurchase, // 1인 최대 구매 수량 추가
+                saleQuantity: ticket.saleQuantity || 0,
+                remainingStock: ticket.remainingStock || 0,
+                salesStartAt: ticket.salesStartAt,
+                salesEndAt: ticket.salesEndAt,
+                visible: ticket.visible !== false // 기본값 true
+            }));
+
+            // 판매 활성화된 티켓만 필터링
+            const visibleTickets = formattedTickets.filter(ticket => ticket.visible);
+            setAvailableTickets(visibleTickets);
+
+        } catch (error) {
+            console.error('회차별 티켓 로드 실패:', error);
+            toast.error('티켓 정보를 불러올 수 없습니다.');
+            setAvailableTickets([]);
+        }
+    }, [eventId]);
 
     useEffect(() => {
         // 모바일 결제 완료 후 리다이렉트 처리
@@ -248,7 +314,7 @@ export const TicketReservation = () => {
             setPaymentStep('결제 상태 확인 중...');
 
             // 저장된 정보로 결제 상태 확인 시도
-            const savedMerchantUid = localStorage.getItem('pending_merchant_uid');
+            const savedMerchantUid = getPendingPaymentItem('pending_merchant_uid');
             if (savedMerchantUid) {
                 // TODO: 결제 상태 확인 API 호출
                 toast.info('결제 상태를 확인 중입니다...');
@@ -260,6 +326,7 @@ export const TicketReservation = () => {
         } else if (impSuccess === 'false') {
             // 결제 취소 또는 실패 시 URL 파라미터만 정리
             console.log('모바일 결제 취소/실패 감지');
+            clearPendingPaymentStorage();
             const newUrl = new URL(window.location.href);
             newUrl.searchParams.delete('imp_uid');
             newUrl.searchParams.delete('merchant_uid');
@@ -365,43 +432,7 @@ export const TicketReservation = () => {
         };
 
         initializeData();
-    }, [eventId, scheduleId, navigate, impSuccess, impUid, merchantUid, success]);
-
-    // 회차별 티켓 로드 함수
-    const loadScheduleTickets = async (scheduleId: number) => {
-        try {
-            const response = await authManager.authenticatedFetch(`/api/events/${eventId}/schedule/${scheduleId}/tickets`);
-
-            if (!response.ok) {
-                throw new Error(`회차별 티켓 조회 실패: ${response.status}`);
-            }
-
-            const ticketList = await response.json() as ScheduleTicketApiResponse[];
-            console.log('회차별 티켓 목록:', ticketList);
-
-            // 회차별 티켓 정보
-            const formattedTickets = ticketList.map((ticket) => ({
-                ticketId: ticket.ticketId,
-                name: ticket.name,
-                price: ticket.price || 0,
-                maxPurchase: ticket.maxPurchase, // 1인 최대 구매 수량 추가
-                saleQuantity: ticket.saleQuantity || 0,
-                remainingStock: ticket.remainingStock || 0,
-                salesStartAt: ticket.salesStartAt,
-                salesEndAt: ticket.salesEndAt,
-                visible: ticket.visible !== false // 기본값 true
-            }));
-
-            // 판매 활성화된 티켓만 필터링
-            const visibleTickets = formattedTickets.filter(ticket => ticket.visible);
-            setAvailableTickets(visibleTickets);
-
-        } catch (error) {
-            console.error('회차별 티켓 로드 실패:', error);
-            toast.error('티켓 정보를 불러올 수 없습니다.');
-            setAvailableTickets([]);
-        }
-    };
+    }, [eventId, scheduleId, navigate, impSuccess, impUid, merchantUid, success, searchParams, handleMobilePaymentSuccess, loadScheduleTickets]);
 
     // 선택된 티켓 가져오기
     const getSelectedTicket = () => {
@@ -515,133 +546,6 @@ export const TicketReservation = () => {
         };
     }, [isProcessing]);
 
-
-    // 모바일 결제 성공 후 처리 함수
-    const handleMobilePaymentSuccess = async (impUid: string, merchantUid: string) => {
-        // 재미있는 메시지들
-        const funMessages = [
-            '박람회를 지배하는 중...',
-            '공연을 나의 것으로 만드는 중...',
-            '축제의 주인공이 되는 중...',
-            '티켓을 황금으로 변환하는 중...',
-            '최고의 자리를 예약하는 중...'
-        ];
-
-        let messageIndex = 0;
-        setPaymentSuccess(false);
-        setPaymentStep(funMessages[messageIndex]);
-
-        // 메시지 로테이션 인터벌
-        const messageInterval = setInterval(() => {
-            messageIndex = (messageIndex + 1) % funMessages.length;
-            setPaymentStep(funMessages[messageIndex]);
-        }, 1500);
-
-        try {
-            console.log('모바일 결제 완료 처리 시작:', { impUid, merchantUid });
-
-            const savedFormData = readStoredObject<StoredReservationForm>('ticketReservationForm');
-            const savedSelectedTicket = readStoredObject<StoredSelectedTicket>('selectedTicket');
-            const savedQuantity = Number(savedFormData.quantity);
-            const savedPrice = Number(savedSelectedTicket.price);
-            const mobileScheduleId = scheduleId ?? parseStoredNumber(localStorage.getItem('pending_schedule_id'));
-            const mobileTicketId =
-                parseStoredNumber(searchParams.get('ticketId')) ??
-                parseStoredNumber(localStorage.getItem('pending_ticket_id')) ??
-                (typeof savedSelectedTicket.ticketId === 'number' ? savedSelectedTicket.ticketId : null);
-            const mobileAmount =
-                parseStoredNumber(localStorage.getItem('pending_amount')) ??
-                (Number.isFinite(savedPrice) && Number.isFinite(savedQuantity) ? savedPrice * savedQuantity : null);
-
-            if (!mobileScheduleId || !mobileTicketId || mobileAmount === null) {
-                throw new Error('결제 완료에 필요한 예약 정보가 없습니다. 다시 예매를 진행해주세요.');
-            }
-
-            // 1. 결제 완료 처리 API 호출
-            const completeResult = await paymentService.completePayment({
-                merchantUid: merchantUid,
-                impUid: impUid,
-                amount: mobileAmount,
-                scheduleId: mobileScheduleId,
-                ticketId: mobileTicketId
-            });
-            console.log('결제 완료 처리 성공:', completeResult);
-
-            if (savedFormData && savedSelectedTicket) {
-                console.log('저장된 예약 정보로 예약 생성:', { savedFormData, savedSelectedTicket });
-
-                const reservationData = {
-                    scheduleId: mobileScheduleId,
-                    ticketId: mobileTicketId,
-                    quantity: savedFormData.quantity,
-                    totalAmount: mobileAmount
-                };
-
-                // 예약은 결제 완료 시 자동으로 생성됨 (PaymentService에서 처리)
-                console.log('모바일 결제 완료:', { completeResult, reservationData });
-            }
-
-            // 결제 성공 시 localStorage 정리
-            clearPendingPaymentStorage();
-
-            // 메시지 로테이션 중지
-            clearInterval(messageInterval);
-            setPaymentStep('티켓 발급 완료!');
-            setPaymentSuccess(true);
-
-            // PC와 동일하게 2.5초 후 이동 (토스트 알림 제거)
-            setTimeout(() => {
-                navigate('/mypage/reservation');
-            }, 2500);
-
-            // URL 정리
-            const newUrl = new URL(window.location.href);
-            newUrl.searchParams.delete('imp_uid');
-            newUrl.searchParams.delete('merchant_uid');
-            newUrl.searchParams.delete('imp_success');
-            window.history.replaceState({}, '', newUrl);
-
-        } catch (error) {
-            console.error('모바일 결제 완료 처리 오류:', error);
-            // 메시지 로테이션 중지
-            clearInterval(messageInterval);
-            setPaymentStep('결제 실패');
-
-            // 모바일 결제 실패 시 백엔드 락도 해제
-            try {
-                await authManager.authenticatedFetch('/api/payments/status/clear', {
-                    method: 'POST'
-                });
-                console.log('백엔드 결제 락 해제 완료');
-            } catch (clearError) {
-                console.warn('백엔드 결제 락 해제 실패:', clearError);
-            }
-
-            // PC와 동일한 상세 에러 메시지 처리
-            let errorMessage = '결제 완료 처리 중 오류가 발생했습니다.';
-            if (error instanceof Error) {
-                if (error.message.includes('network') || error.message.includes('fetch')) {
-                    errorMessage = '네트워크 오류가 발생했습니다. 인터넷 연결을 확인해주세요.';
-                } else {
-                    errorMessage = error.message;
-                }
-            }
-
-            toast.error(errorMessage);
-
-            // PC와 동일하게 3초 후 상태 초기화
-            setTimeout(() => {
-                setPaymentStep('');
-                setPaymentSuccess(false);
-            }, 3000);
-        } finally {
-            // 메시지 로테이션 정리 (에러가 발생하더라도 인터벌 정리)
-            clearInterval(messageInterval);
-            // PC와 동일한 상태 초기화
-            setIsProcessing(false);
-        }
-    };
-
     // 중복 클릭 방지 및 결제 처리 함수
     const handlePayment = async () => {
         // ================================= 생년월일 검증 로직 =================================
@@ -750,15 +654,14 @@ export const TicketReservation = () => {
 
             setPaymentStep('결제 처리 중...');
 
-            // PG사 중간 페이지 감지를 위한 정보 저장 (최소화)
-            const tempMerchantUid = `TICKET_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
-            localStorage.setItem('pending_merchant_uid', tempMerchantUid);
-            localStorage.setItem('pending_event_id', eventId);
-            localStorage.setItem('pending_schedule_id', String(scheduleId));
-            localStorage.setItem('pending_ticket_id', String(selectedTicket.ticketId));
-            localStorage.setItem('pending_amount', String(totalAmount));
-            localStorage.setItem('ticketReservationForm', JSON.stringify(ticketReservationForm));
-            localStorage.setItem('selectedTicket', JSON.stringify(selectedTicket));
+            // 모바일 redirect 복구용 정보는 결제 완료에 필요한 최소값만 저장합니다.
+            const paymentMerchantUid = await paymentService.generateMerchantUid(paymentTargetType);
+            setPendingPaymentItem('pending_merchant_uid', paymentMerchantUid);
+            setPendingPaymentItem('pending_event_id', eventId);
+            setPendingPaymentItem('pending_schedule_id', String(scheduleId));
+            setPendingPaymentItem('pending_ticket_id', String(selectedTicket.ticketId));
+            setPendingPaymentItem('pending_amount', String(totalAmount));
+            setPendingPaymentItem('pending_quantity', String(ticketReservationForm.quantity));
 
             // 결제 처리 (결제 → 예약 생성 → target_id 업데이트)
             const result = await paymentService.processPayment(
@@ -770,7 +673,8 @@ export const TicketReservation = () => {
                 ticketReservationForm.quantity,
                 selectedTicket.price,
                 totalAmount,
-                reservationData
+                reservationData,
+                paymentMerchantUid
             );
 
             setPaymentStep('티켓 발급 중...');
@@ -791,6 +695,7 @@ export const TicketReservation = () => {
         } catch (error) {
             console.error('결제 처리 중 오류:', error);
             setPaymentStep('결제 실패');
+            clearPendingPaymentStorage();
 
             // 결제 실패 시 백엔드 락도 해제
             try {

--- a/src/pages/user_event/TicketReservation.tsx
+++ b/src/pages/user_event/TicketReservation.tsx
@@ -8,7 +8,6 @@ import authManager from "../../utils/auth";
 import paymentService from "../../services/paymentService";
 import NewLoader from "../../components/NewLoader";
 import { useScrollToTop } from "../../hooks/useScrollToTop";
-import { useAuth } from "../../context/AuthContext";
 
 // 이벤트 회차 정보
 interface EventSchedule {
@@ -33,6 +32,18 @@ interface TicketReservationOption {
     visible: boolean;
 }
 
+interface ScheduleTicketApiResponse {
+    ticketId: number;
+    name: string;
+    price?: number;
+    maxPurchase?: number;
+    saleQuantity?: number;
+    remainingStock?: number;
+    salesStartAt?: string;
+    salesEndAt?: string;
+    visible?: boolean;
+}
+
 // 이벤트 상세 정보 (예매 페이지에서 실제 사용되는 필드만)
 interface EventDetail {
     titleKr: string;
@@ -54,6 +65,47 @@ interface TicketReservationForm {
     paymentMethod: string;
 }
 
+interface StoredReservationForm {
+    quantity?: number;
+}
+
+interface StoredSelectedTicket {
+    ticketId?: number;
+    price?: number;
+}
+
+const PENDING_PAYMENT_KEYS = [
+    'pending_imp_uid',
+    'pending_merchant_uid',
+    'pending_event_id',
+    'pending_schedule_id',
+    'pending_ticket_id',
+    'pending_amount',
+    'ticketReservationForm',
+    'selectedTicket'
+];
+
+const parseStoredNumber = (value: string | null): number | null => {
+    if (!value) return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+};
+
+const readStoredObject = <T extends object>(key: string): Partial<T> => {
+    try {
+        const value = localStorage.getItem(key);
+        if (!value) return {};
+        const parsed: unknown = JSON.parse(value);
+        return parsed && typeof parsed === 'object' ? parsed as Partial<T> : {};
+    } catch {
+        return {};
+    }
+};
+
+const clearPendingPaymentStorage = () => {
+    PENDING_PAYMENT_KEYS.forEach(key => localStorage.removeItem(key));
+};
+
 export const TicketReservation = () => {
     useScrollToTop();
     // eventId
@@ -61,10 +113,6 @@ export const TicketReservation = () => {
     const navigate = useNavigate();
     const [searchParams] = useSearchParams();
     
-    // ================================= 생년월일 검증용 추가 =================================
-    const { user } = useAuth();
-    // ====================================================================================
-
     // URL 파라미터에서 scheduleId 가져오기
     const scheduleIdParam = searchParams.get('scheduleId');
     const scheduleId = scheduleIdParam ? parseInt(scheduleIdParam) : null;
@@ -84,7 +132,7 @@ export const TicketReservation = () => {
     // 중복 클릭 방지를 위한 상태
     const [isProcessing, setIsProcessing] = useState(
         // PG사 결제 완료 시 즉시 로딩 상태로 시작
-        impSuccess === 'true' && impUid && merchantUid
+        Boolean(impSuccess === 'true' && impUid && merchantUid)
     );
     const [paymentAttempts, setPaymentAttempts] = useState(0);
     const [lastAttemptTime, setLastAttemptTime] = useState(0);
@@ -100,7 +148,7 @@ export const TicketReservation = () => {
         buyer_name: "",
         buyer_phone: "",
         buyer_email: "",
-        buyer_id: "",
+        buyer_id: 0,
         paymentMethod: "card"
     });
 
@@ -212,7 +260,7 @@ export const TicketReservation = () => {
         } else if (impSuccess === 'false') {
             // 결제 취소 또는 실패 시 URL 파라미터만 정리
             console.log('모바일 결제 취소/실패 감지');
-            const newUrl = new URL(window.location);
+            const newUrl = new URL(window.location.href);
             newUrl.searchParams.delete('imp_uid');
             newUrl.searchParams.delete('merchant_uid');
             newUrl.searchParams.delete('imp_success');
@@ -221,7 +269,7 @@ export const TicketReservation = () => {
             // 기존 success=true 파라미터 처리 (호환성)
             toast.success('결제가 성공적으로 완료되었습니다!');
             // URL에서 success 파라미터 제거
-            const newUrl = new URL(window.location);
+            const newUrl = new URL(window.location.href);
             newUrl.searchParams.delete('success');
             window.history.replaceState({}, '', newUrl);
         }
@@ -237,7 +285,7 @@ export const TicketReservation = () => {
                     buyer_name: userData.name || "",
                     buyer_phone: userData.phone || "",
                     buyer_email: userData.email || "",
-                    buyer_id: userData.userId || ""
+                    buyer_id: userData.userId || 0
                 }));
             } catch {
                 console.error("사용자 정보 로드 실패");
@@ -328,11 +376,11 @@ export const TicketReservation = () => {
                 throw new Error(`회차별 티켓 조회 실패: ${response.status}`);
             }
 
-            const ticketList = await response.json();
+            const ticketList = await response.json() as ScheduleTicketApiResponse[];
             console.log('회차별 티켓 목록:', ticketList);
 
             // 회차별 티켓 정보
-            const formattedTickets = ticketList.map((ticket: any) => ({
+            const formattedTickets = ticketList.map((ticket) => ({
                 ticketId: ticket.ticketId,
                 name: ticket.name,
                 price: ticket.price || 0,
@@ -492,58 +540,49 @@ export const TicketReservation = () => {
         try {
             console.log('모바일 결제 완료 처리 시작:', { impUid, merchantUid });
 
-            // 1. 결제 완료 처리 API 호출
-            const backendUrl = import.meta.env.VITE_BACKEND_BASE_URL || window.location.origin;
-            const completeResponse = await fetch(`${backendUrl}/api/payments/complete`, {
-                method: 'POST',
-                credentials: 'include', // HTTP-only 쿠키 자동 전송
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                    merchantUid: merchantUid,
-                    impUid: impUid
-                })
-            });
+            const savedFormData = readStoredObject<StoredReservationForm>('ticketReservationForm');
+            const savedSelectedTicket = readStoredObject<StoredSelectedTicket>('selectedTicket');
+            const savedQuantity = Number(savedFormData.quantity);
+            const savedPrice = Number(savedSelectedTicket.price);
+            const mobileScheduleId = scheduleId ?? parseStoredNumber(localStorage.getItem('pending_schedule_id'));
+            const mobileTicketId =
+                parseStoredNumber(searchParams.get('ticketId')) ??
+                parseStoredNumber(localStorage.getItem('pending_ticket_id')) ??
+                (typeof savedSelectedTicket.ticketId === 'number' ? savedSelectedTicket.ticketId : null);
+            const mobileAmount =
+                parseStoredNumber(localStorage.getItem('pending_amount')) ??
+                (Number.isFinite(savedPrice) && Number.isFinite(savedQuantity) ? savedPrice * savedQuantity : null);
 
-            if (!completeResponse.ok) {
-                if (completeResponse.status === 401) {
-                    window.dispatchEvent(new CustomEvent('auth:unauthorized'));
-                    throw new Error('인증이 만료되었습니다. 다시 로그인해주세요.');
-                }
-                throw new Error(`결제 완료 처리 실패: ${completeResponse.status}`);
+            if (!mobileScheduleId || !mobileTicketId || mobileAmount === null) {
+                throw new Error('결제 완료에 필요한 예약 정보가 없습니다. 다시 예매를 진행해주세요.');
             }
 
-            const completeResult = await completeResponse.json();
+            // 1. 결제 완료 처리 API 호출
+            const completeResult = await paymentService.completePayment({
+                merchantUid: merchantUid,
+                impUid: impUid,
+                amount: mobileAmount,
+                scheduleId: mobileScheduleId,
+                ticketId: mobileTicketId
+            });
             console.log('결제 완료 처리 성공:', completeResult);
-
-            // 2. 저장된 폼 데이터로 예약 생성 (PC와 동일한 로직)
-            const savedFormData = JSON.parse(localStorage.getItem('ticketReservationForm') || '{}');
-            const savedSelectedTicket = JSON.parse(localStorage.getItem('selectedTicket') || '{}');
 
             if (savedFormData && savedSelectedTicket) {
                 console.log('저장된 예약 정보로 예약 생성:', { savedFormData, savedSelectedTicket });
 
                 const reservationData = {
-                    scheduleId: scheduleId,
-                    ticketId: savedSelectedTicket.ticketId,
+                    scheduleId: mobileScheduleId,
+                    ticketId: mobileTicketId,
                     quantity: savedFormData.quantity,
-                    totalAmount: savedSelectedTicket.price * savedFormData.quantity,
-                    buyer_name: savedFormData.buyer_name,
-                    buyer_phone: savedFormData.buyer_phone,
-                    buyer_email: savedFormData.buyer_email,
-                    paymentMethod: savedFormData.paymentMethod || 'card'
+                    totalAmount: mobileAmount
                 };
 
                 // 예약은 결제 완료 시 자동으로 생성됨 (PaymentService에서 처리)
-                console.log('모바일 결제 완료:', completeResult);
+                console.log('모바일 결제 완료:', { completeResult, reservationData });
             }
 
             // 결제 성공 시 localStorage 정리
-            localStorage.removeItem('pending_imp_uid');
-            localStorage.removeItem('pending_merchant_uid');
-            localStorage.removeItem('pending_event_id');
-            localStorage.removeItem('pending_schedule_id');
+            clearPendingPaymentStorage();
 
             // 메시지 로테이션 중지
             clearInterval(messageInterval);
@@ -556,7 +595,7 @@ export const TicketReservation = () => {
             }, 2500);
 
             // URL 정리
-            const newUrl = new URL(window.location);
+            const newUrl = new URL(window.location.href);
             newUrl.searchParams.delete('imp_uid');
             newUrl.searchParams.delete('merchant_uid');
             newUrl.searchParams.delete('imp_success');
@@ -672,6 +711,16 @@ export const TicketReservation = () => {
             return;
         }
 
+        if (!scheduleId) {
+            toast.error('회차 정보가 없습니다. 이벤트 상세 페이지에서 회차를 다시 선택해주세요.');
+            return;
+        }
+
+        if (!eventId || !eventData) {
+            toast.error('이벤트 정보를 확인할 수 없습니다. 다시 시도해주세요.');
+            return;
+        }
+
         const totalAmount = calculateTotal();
         const paymentTargetType = "RESERVATION";
 
@@ -705,7 +754,11 @@ export const TicketReservation = () => {
             const tempMerchantUid = `TICKET_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
             localStorage.setItem('pending_merchant_uid', tempMerchantUid);
             localStorage.setItem('pending_event_id', eventId);
-            localStorage.setItem('pending_schedule_id', scheduleId);
+            localStorage.setItem('pending_schedule_id', String(scheduleId));
+            localStorage.setItem('pending_ticket_id', String(selectedTicket.ticketId));
+            localStorage.setItem('pending_amount', String(totalAmount));
+            localStorage.setItem('ticketReservationForm', JSON.stringify(ticketReservationForm));
+            localStorage.setItem('selectedTicket', JSON.stringify(selectedTicket));
 
             // 결제 처리 (결제 → 예약 생성 → target_id 업데이트)
             const result = await paymentService.processPayment(
@@ -725,10 +778,7 @@ export const TicketReservation = () => {
             console.log('결제 및 예약 성공:', result);
 
             // 결제 성공 시 localStorage 정리
-            localStorage.removeItem('pending_imp_uid');
-            localStorage.removeItem('pending_merchant_uid');
-            localStorage.removeItem('pending_event_id');
-            localStorage.removeItem('pending_schedule_id');
+            clearPendingPaymentStorage();
 
             setPaymentStep('결제 완료!');
             setPaymentSuccess(true);
@@ -1232,7 +1282,7 @@ export const TicketReservation = () => {
             </div>
 
             {/* 커스텀 CSS 애니메이션 */}
-            <style jsx>{`
+            <style>{`
                 @keyframes fade-in {
                     from { opacity: 0; transform: translateY(20px); }
                     to { opacity: 1; transform: translateY(0); }

--- a/src/services/paymentService.ts
+++ b/src/services/paymentService.ts
@@ -1,6 +1,29 @@
 // 아임포트 결제 서비스
 import authManager from "../utils/auth";
-import ticketReservationService from "./ticketReservationService";
+
+type ApiObject = Record<string, unknown>;
+
+interface PaymentSaveResponse extends ApiObject {
+    paymentId?: number;
+}
+
+interface PaymentCompleteResponse extends ApiObject {
+    targetId?: number | string;
+}
+
+interface FreeTicketResponse extends PaymentCompleteResponse {
+    paymentId?: number;
+    merchantUid?: string;
+    impUid?: string;
+}
+
+interface PaymentProcessResult {
+    success: boolean;
+    paymentId?: number;
+    paymentResponse: IamportResponse;
+    completionResult: PaymentCompleteResponse | FreeTicketResponse;
+    targetId: number | string;
+}
 
 // 아임포트 타입 선언
 declare global {
@@ -44,8 +67,19 @@ export interface PaymentCompletionRequest {
     impUid: string;
     amount: number;
     applyNum?: string; // 카드 승인번호
-    scheduleId?: number;
-    ticketId?: number;
+    scheduleId: number;
+    ticketId: number;
+}
+
+export interface ReservationPaymentData {
+    scheduleId: number;
+    ticketId: number;
+    quantity: number;
+    totalAmount: number;
+    buyer_name: string;
+    buyer_phone: string;
+    buyer_email: string;
+    paymentMethod: string;
 }
 
 // 아임포트 응답 인터페이스
@@ -165,7 +199,7 @@ class PaymentService {
     /**
      * 환불 요청
      */
-    async requestRefund(refundData: RefundRequest): Promise<any> {
+    async requestRefund(refundData: RefundRequest): Promise<ApiObject> {
         try {
             const response = await authManager.authenticatedFetch(`/api/refunds/${refundData.paymentId}/request`, {
                 method: 'POST',
@@ -184,7 +218,7 @@ class PaymentService {
                 throw new Error(`환불 요청 실패: ${response.status} - ${errorData}`);
             }
 
-            return await response.json();
+            return await response.json() as ApiObject;
         } catch (error) {
             console.error('환불 요청 중 오류:', error);
             throw error;
@@ -194,7 +228,7 @@ class PaymentService {
     /**
      * 환불 승인
      */
-    async approveRefund(refundId: number): Promise<any> {
+    async approveRefund(refundId: number): Promise<ApiObject> {
         try {
             const response = await authManager.authenticatedFetch(`/api/refunds/${refundId}/approve`, {
                 method: 'POST',
@@ -208,7 +242,7 @@ class PaymentService {
                 throw new Error(`환불 승인 실패: ${response.status} - ${errorData}`);
             }
 
-            return await response.json();
+            return await response.json() as ApiObject;
         } catch (error) {
             console.error('환불 승인 중 오류:', error);
             throw error;
@@ -227,8 +261,8 @@ class PaymentService {
         quantity:number,
         price:number,
         amount:number,
-        reservationData?: any
-    ): Promise<any> {
+        reservationData: ReservationPaymentData
+    ): Promise<PaymentProcessResult> {
         try {
             // 무료 티켓인지 확인
             if (amount === 0) {
@@ -249,8 +283,8 @@ class PaymentService {
                 amount: amount,
                 merchantUid: merchantUid,
                 pgProvider: 'uplus',
-                scheduleId: reservationData?.scheduleId,
-                ticketId: reservationData?.ticketId,
+                scheduleId: reservationData.scheduleId,
+                ticketId: reservationData.ticketId,
                 reservationData: reservationData
             });
             
@@ -262,17 +296,14 @@ class PaymentService {
                 amount:amount,
                 merchantUid: merchantUid,
                 pgProvider: 'uplus',
-                scheduleId: reservationData?.scheduleId,
-                ticketId: reservationData?.ticketId
+                scheduleId: reservationData.scheduleId,
+                ticketId: reservationData.ticketId
             });
             
             console.log('저장된 paymentId:', savedPayment.paymentId);
 
             // 3. 결제 요청 데이터 준비
-            const scheduleId = reservationData?.scheduleId;
-            const redirectUrl = scheduleId 
-                ? `${window.location.origin}/ticket-reservation/${eventId}?scheduleId=${scheduleId}&success=true`
-                : `${window.location.origin}/ticket-reservation/${eventId}?success=true`;
+            const redirectUrl = `${window.location.origin}/ticket-reservation/${eventId}?scheduleId=${reservationData.scheduleId}&ticketId=${reservationData.ticketId}&success=true`;
                 
             const paymentRequest: PaymentRequest = {
                 pg: 'uplus',
@@ -298,8 +329,8 @@ class PaymentService {
                 impUid: paymentResponse.imp_uid!,
                 amount: paymentResponse.paid_amount!,
                 applyNum: paymentResponse.apply_num,
-                scheduleId: reservationData?.scheduleId,
-                ticketId: reservationData?.ticketId
+                scheduleId: reservationData.scheduleId,
+                ticketId: reservationData.ticketId
             });
 
             console.log('결제 완료 결과:', completionResult);
@@ -307,7 +338,7 @@ class PaymentService {
             // completionResult에서 targetId를 가져옵니다 (백엔드에서 예약 생성 후 반환)
             const targetId = completionResult.targetId;
             
-            if (!targetId) {
+            if (targetId == null) {
                 throw new Error('결제 완료 후 예약 ID를 가져올 수 없습니다.');
             }
 
@@ -337,11 +368,15 @@ class PaymentService {
         eventId: number,
         paymentTargetType: string,
         quantity: number,
-        price: number,
-        amount: number,
-        reservationData?: any
-    ): Promise<any> {
+        _price: number,
+        _amount: number,
+        _reservationData: ReservationPaymentData
+    ): Promise<PaymentProcessResult> {
         try {
+            void _price;
+            void _amount;
+            void _reservationData;
+
             const merchantUid = await this.generateMerchantUid(paymentTargetType);
             console.log('무료 티켓 처리 - merchantUid:', merchantUid);
 
@@ -362,7 +397,7 @@ class PaymentService {
             // freeTicketResult에서 targetId를 가져옵니다 (백엔드에서 예약 생성 후 반환)
             const targetId = freeTicketResult.targetId;
             
-            if (!targetId) {
+            if (targetId == null) {
                 throw new Error('무료 티켓 처리 후 예약 ID를 가져올 수 없습니다.');
             }
 
@@ -373,7 +408,7 @@ class PaymentService {
                 paymentId: freeTicketResult.paymentId,
                 paymentResponse: {
                     success: true,
-                    merchant_uid: freeTicketResult.merchantUid,
+                    merchant_uid: freeTicketResult.merchantUid ?? merchantUid,
                     imp_uid: freeTicketResult.impUid,
                     paid_amount: 0,
                     apply_num: 'FREE_TICKET'
@@ -399,9 +434,9 @@ class PaymentService {
         amount: number;
         merchantUid: string;
         pgProvider: string;
-        scheduleId?: number;
-        ticketId?: number;
-    }): Promise<any> {
+        scheduleId: number;
+        ticketId: number;
+    }): Promise<PaymentSaveResponse> {
         try {
             const response = await authManager.authenticatedFetch('/api/payments/request', {
                 method: 'POST',
@@ -426,7 +461,7 @@ class PaymentService {
                 throw new Error(`결제 요청 저장 실패: ${response.status} - ${errorData}`);
             }
 
-            return await response.json();
+            return await response.json() as PaymentSaveResponse;
         } catch (error) {
             console.error('결제 요청 저장 중 오류:', error);
             throw error;
@@ -443,7 +478,7 @@ class PaymentService {
         price: number;
         merchantUid: string;
         pgProvider: string;
-    }): Promise<any> {
+    }): Promise<FreeTicketResponse> {
         try {
             const response = await authManager.authenticatedFetch('/api/payments/free', {
                 method: 'POST',
@@ -465,7 +500,7 @@ class PaymentService {
                 throw new Error(`무료 티켓 처리 실패: ${response.status} - ${errorData}`);
             }
 
-            return await response.json();
+            return await response.json() as FreeTicketResponse;
         } catch (error) {
             console.error('무료 티켓 서버 처리 중 오류:', error);
             throw error;
@@ -475,7 +510,7 @@ class PaymentService {
     /**
      * 결제 완료 처리 (백엔드로 결과 전송)
      */
-    async completePayment(completionData: PaymentCompletionRequest): Promise<any> {
+    async completePayment(completionData: PaymentCompletionRequest): Promise<PaymentCompleteResponse> {
         try {
             const response = await authManager.authenticatedFetch('/api/payments/complete', {
                 method: 'POST',
@@ -497,7 +532,7 @@ class PaymentService {
                 throw new Error(`결제 완료 처리 실패: ${response.status} - ${errorData}`);
             }
 
-            return await response.json();
+            return await response.json() as PaymentCompleteResponse;
         } catch (error) {
             console.error('결제 완료 처리 중 오류:', error);
             throw error;

--- a/src/services/paymentService.ts
+++ b/src/services/paymentService.ts
@@ -363,9 +363,9 @@ class PaymentService {
      * 무료 티켓 처리 (PG사 연동 없이 직접 처리)
      */
     async processFreeTicket(
-        title: string,
-        userId: number,
-        userName: string,
+        _title: string,
+        _userId: number,
+        _userName: string,
         eventId: number,
         paymentTargetType: string,
         quantity: number,
@@ -375,6 +375,9 @@ class PaymentService {
         merchantUid?: string
     ): Promise<PaymentProcessResult> {
         try {
+            void _title;
+            void _userId;
+            void _userName;
             void _price;
             void _amount;
             void _reservationData;

--- a/src/services/paymentService.ts
+++ b/src/services/paymentService.ts
@@ -261,18 +261,19 @@ class PaymentService {
         quantity:number,
         price:number,
         amount:number,
-        reservationData: ReservationPaymentData
+        reservationData: ReservationPaymentData,
+        merchantUid?: string
     ): Promise<PaymentProcessResult> {
         try {
             // 무료 티켓인지 확인
             if (amount === 0) {
                 return await this.processFreeTicket(
-                    title, userId, userName, eventId, paymentTargetType, quantity, price, amount, reservationData
+                    title, userId, userName, eventId, paymentTargetType, quantity, price, amount, reservationData, merchantUid
                 );
             }
 
-            const merchantUid = await this.generateMerchantUid(paymentTargetType);
-            console.log('merchantUid:', merchantUid);
+            const paymentMerchantUid = merchantUid ?? await this.generateMerchantUid(paymentTargetType);
+            console.log('merchantUid:', paymentMerchantUid);
 
             // 1. 백엔드에 결제 요청 정보 저장 (PENDING 상태) - paymentId 반환
             console.log('🔵 [PaymentService] savePaymentRequest 데이터:', {
@@ -281,7 +282,7 @@ class PaymentService {
                 quantity: quantity,
                 price: amount / quantity,
                 amount: amount,
-                merchantUid: merchantUid,
+                merchantUid: paymentMerchantUid,
                 pgProvider: 'uplus',
                 scheduleId: reservationData.scheduleId,
                 ticketId: reservationData.ticketId,
@@ -294,7 +295,7 @@ class PaymentService {
                 quantity: quantity,
                 price: amount / quantity,
                 amount:amount,
-                merchantUid: merchantUid,
+                merchantUid: paymentMerchantUid,
                 pgProvider: 'uplus',
                 scheduleId: reservationData.scheduleId,
                 ticketId: reservationData.ticketId
@@ -308,7 +309,7 @@ class PaymentService {
             const paymentRequest: PaymentRequest = {
                 pg: 'uplus',
                 pay_method: 'card',
-                merchant_uid: merchantUid,
+                merchant_uid: paymentMerchantUid,
                 name: `${title}`,
                 amount: amount,
                 buyer_name: userName,
@@ -370,15 +371,16 @@ class PaymentService {
         quantity: number,
         _price: number,
         _amount: number,
-        _reservationData: ReservationPaymentData
+        _reservationData: ReservationPaymentData,
+        merchantUid?: string
     ): Promise<PaymentProcessResult> {
         try {
             void _price;
             void _amount;
             void _reservationData;
 
-            const merchantUid = await this.generateMerchantUid(paymentTargetType);
-            console.log('무료 티켓 처리 - merchantUid:', merchantUid);
+            const paymentMerchantUid = merchantUid ?? await this.generateMerchantUid(paymentTargetType);
+            console.log('무료 티켓 처리 - merchantUid:', paymentMerchantUid);
 
             // 1. 무료 티켓 직접 처리 (백엔드에서 즉시 완료 처리) - paymentId 반환
             const freeTicketResult = await this.processFreeTicketOnServer({
@@ -386,7 +388,7 @@ class PaymentService {
                 paymentTargetType: paymentTargetType,
                 quantity: quantity,
                 price: 0, // 무료 티켓이므로 0
-                merchantUid: merchantUid,
+                merchantUid: paymentMerchantUid,
                 pgProvider: 'free'
             });
             
@@ -408,7 +410,7 @@ class PaymentService {
                 paymentId: freeTicketResult.paymentId,
                 paymentResponse: {
                     success: true,
-                    merchant_uid: freeTicketResult.merchantUid ?? merchantUid,
+                    merchant_uid: freeTicketResult.merchantUid ?? paymentMerchantUid,
                     imp_uid: freeTicketResult.impUid,
                     paid_amount: 0,
                     apply_num: 'FREE_TICKET'


### PR DESCRIPTION
## 요약
- 결제 요청/완료 계약에서 scheduleId와 ticketId 예약 문맥을 유지해 BE intent-binding 요구사항과 맞췄습니다.
- 모바일 리다이렉트 복구는 하나의 merchantUid에 묶고 session storage에는 최소 복구 힌트만 저장하도록 정리했습니다.
- 무료 티켓 처리 계약은 유지하되 TypeScript lint가 의도적으로 미사용인 인자를 구분하도록 보강했습니다.

## 검증 evidence
- `npm run build`
- `npm run lint:changed`
- `npm run typecheck:changed`
- `git diff --check`

## 남은 gap
- live PortOne/Redis/PG smoke 미실행
- P0-01 live mini-server stack not running
- CodeRabbit rate-limit은 non-blocking policy로 취급

## main 보호
- 이 PR은 `epic/security-payment-intent-confirm` -> `develop` 대상입니다.
- `main`은 건드리지 않습니다. develop/main merge는 수행하지 않습니다.