### PR TITLE
Move QR and waiting clients to authenticated SSE

### DIFF
--- a/src/pages/OnlyQrTicketPage.tsx
+++ b/src/pages/OnlyQrTicketPage.tsx
@@ -1,11 +1,10 @@
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import {
     Calendar,
     MapPin,
     RefreshCw,
     User,
     AlertCircle,
-    Check,
     Ban
 } from "lucide-react";
 
@@ -17,11 +16,10 @@ import {
 import { QRCodeCanvas } from 'qrcode.react';
 import type {
     QrTicketReissueGuestRequestDto,
-    QrTicketGuestResponseDto,
-    QrTicketResponseDto
+    QrTicketGuestResponseDto
 } from "../services/types/qrTicketType";
 import { useSearchParams, useNavigate } from "react-router-dom";
-import { useQrTicketSocket } from "../utils/useQrTicketSocket";
+import axios from "axios";
 
 
 // 스크롤바 숨기기 CSS
@@ -41,29 +39,10 @@ export const OnlyQrTicketPage = () => {
     const navigate = useNavigate();
     const token = searchParam.get("token");
     const [timeLeft, setTimeLeft] = useState(300); // 5분 = 300초
-    const [qrTicketId, setQrTicketId] = useState(0);
     const [qrCode, setQrCode] = useState(""); // QR 코드 상태
     const [manualCode, setManualCode] = useState(""); // 수동 코드 상태
     const [resData, setResData] = useState<QrTicketGuestResponseDto | null>(null);
-    const [isTicketUsed, setIsTicketUsed] = useState(false);
     const timerRef = useRef<NodeJS.Timeout | null>(null);
-    const [successMessage, setSuccessMessage] = useState("");
-    const [updateIds, setUpdateIds] = useState({
-        reservationId: 0,
-        qrTicketId: 0
-    });
-
-    // 웹소켓 메시지 핸들러를 useCallback으로 메모이제이션
-    const handleWebSocketMessage = useCallback((msg: string) => {
-        setSuccessMessage(msg);
-        // 입장 완료 상태로 변경
-        setIsTicketUsed(true);
-        // 타이머 멈추기
-        if (timerRef.current) clearInterval(timerRef.current);
-    }, []);
-
-    // ✅ 웹소켓 구독 (qrTicketId가 유효할 때만)
-    useQrTicketSocket(qrTicketId > 0 ? qrTicketId : 0, handleWebSocketMessage);
 
     // QR 코드와 수동 코드 초기화 + 모달 오픈 시 타이머 시작
     useEffect(() => {
@@ -98,10 +77,9 @@ export const OnlyQrTicketPage = () => {
                 setResData(data);
                 setQrCode(data.qrCode);
                 setManualCode(data.manualCode);
-                setQrTicketId(data.qrTicketId);
                 console.log(data);
-            } catch (error: any) {
-                if (error.response) {  
+            } catch (error: unknown) {
+                if (axios.isAxiosError<{ message?: string }>(error) && error.response) {
                     const { message } = error.response.data;
                     navigate(`/qr-ticket/participant/error`, {
                         state: {
@@ -109,7 +87,7 @@ export const OnlyQrTicketPage = () => {
                             message: message,
                     }
                 });
-                } else if (error.request) {
+                } else if (axios.isAxiosError(error) && error.request) {
                     navigate(`/qr-ticket/participant/error`, {
                         state: {
                             title: "죄송합니다",
@@ -127,7 +105,7 @@ export const OnlyQrTicketPage = () => {
             }
         };
         getMyTicketInfo();
-    }, []);
+    }, [navigate, token]);
 
     // 새로고침 함수
     const handleRefresh = async () => {
@@ -143,7 +121,6 @@ export const OnlyQrTicketPage = () => {
         const res = await reissueQrTicketByGuest(data);
         setQrCode(res.qrCode);
         setManualCode(res.manualCode);
-        setIsTicketUsed(false);
         setTimeLeft(300); // 타이머 리셋
     };
 
@@ -180,11 +157,6 @@ export const OnlyQrTicketPage = () => {
 
                 {/* QR 코드 섹션 */}
                 <div className="p-2 sm:p-3 md:p-4">
-                    {isTicketUsed && (
-                        <div className="text-center mb-4 p-2 bg-green-100 text-green-800 font-semibold rounded-lg">
-                                ✅ {successMessage}
-                        </div>
-                    )}
                     {timeLeft === 0 && (
                         <div className="text-center mb-4 p-2 rounded-lg font-semibold 
                                         bg-red-100 text-red-800">
@@ -198,8 +170,6 @@ export const OnlyQrTicketPage = () => {
                                     <div className="w-16 h-16 sm:w-20 md:w-24 sm:h-20 md:h-24 bg-gray-200 rounded-md sm:rounded-lg flex items-center justify-center">
                                         {timeLeft === 0 ? (
                                             <Ban size={120} color="#ff0000" strokeWidth={2.25} />
-                                        ): isTicketUsed ? (
-                                            <Check size={120} color="#613cf4ff" strokeWidth={2.25} />
                                         ) : (
                                             <QRCodeCanvas value={qrCode} size={120} fgColor={'#000'} />
                                         )}
@@ -209,9 +179,7 @@ export const OnlyQrTicketPage = () => {
                         </div>
 
                         <div className="text-center">
-                            {!isTicketUsed && (
-                                <p className="text-xs sm:text-sm font-mono text-gray-600 mb-2">{manualCode}</p>
-                            )}
+                            <p className="text-xs sm:text-sm font-mono text-gray-600 mb-2">{manualCode}</p>
                             <p className="font-mono text-xs sm:text-sm text-gray-600 mb-2">TicketNo.{resData?.ticketNo}</p>
                             <div className="flex items-center justify-center space-x-2 text-xs text-gray-500">
                                 <div className="w-2 h-2 bg-green-500 rounded-full"></div>

--- a/src/utils/useQrTicketSocket.tsx
+++ b/src/utils/useQrTicketSocket.tsx
@@ -1,11 +1,7 @@
 import { useEffect, useRef, useCallback } from "react";
-import SockJS from "sockjs-client";
-import Stomp from "stompjs";
-
 
 export function useQrTicketSocket(qrTicketId: number, onMessage: (msg: string) => void) {
-    const clientRef = useRef<Stomp.Client | null>(null);
-    const subscriptionsRef = useRef<Stomp.Subscription[]>([]);
+    const eventSourceRef = useRef<EventSource | null>(null);
     const onMessageRef = useRef(onMessage);
     
     // onMessage 콜백을 ref에 저장하여 최신 버전 유지
@@ -20,68 +16,35 @@ export function useQrTicketSocket(qrTicketId: number, onMessage: (msg: string) =
   useEffect(() => {
     if (!qrTicketId) return;
 
-    // 이미 연결된 상태라면 중복 연결 방지
-    if (clientRef.current && clientRef.current.connected) {
-        console.log("이미 웹소켓이 연결되어 있습니다. 중복 연결을 방지합니다.");
+    if (eventSourceRef.current) {
+        console.log("이미 QR SSE가 연결되어 있습니다. 중복 연결을 방지합니다.");
         return;
     }
 
-    const sock = new SockJS(`${import.meta.env.VITE_BACKEND_BASE_URL}/ws/qr-sockjs`);
-    const stomp = Stomp.over(sock);
+    const backendUrl = import.meta.env.VITE_BACKEND_BASE_URL || window.location.origin;
+    const eventSource = new EventSource(`${backendUrl}/api/qr-tickets/${qrTicketId}/stream`, {
+      withCredentials: true,
+    });
+    eventSourceRef.current = eventSource;
 
-    stomp.debug = () => {}; // 로그 끔
-    clientRef.current = stomp;
+    eventSource.addEventListener("qr-ticket-connected", () => {
+      console.log("🔌 QR SSE 연결 성공");
+    });
 
-    stomp.connect(
-          {},
-      () => {
-            console.log("🔌 QR 웹소켓 연결 성공, 구독 시작");
+    eventSource.addEventListener("qr-ticket-status", (event) => {
+      handleMessage(event.data);
+    });
 
-            const subCheckIn = stomp.subscribe(
-            `/topic/check-in/${qrTicketId}`,
-            (message) => {
-                handleMessage(message.body);
-            }
-            );
-
-            const subCheckOut = stomp.subscribe(
-            `/topic/check-out/${qrTicketId}`,
-            (message) => {
-                handleMessage(message.body);
-            }
-            );
-        
-            const subBooth = stomp.subscribe(
-          `/topic/booth/qr/${qrTicketId}`,
-            (message) => {
-              handleMessage(message.body);
-            }
-            );
-        
-            subscriptionsRef.current = [subCheckIn, subCheckOut, subBooth];
-      },
-      (err) => {
-        console.error("QR socket error:", err);
-      }
-    );
+    eventSource.onerror = (error) => {
+      console.error("QR SSE error:", error);
+    };
 
     return () => {
-      // 두 구독 모두 해제
-      subscriptionsRef.current.forEach((sub) => {
-        try {
-          sub.unsubscribe();
-        } catch (e) {
-          console.warn("구독 해제 중 오류:", e);
-        }
-      });
-      subscriptionsRef.current = [];
-      
-      if (clientRef.current?.connected) {
-        clientRef.current.disconnect(() => {
-          console.log("🔌 QR 웹소켓 연결 해제");
-        });
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close();
+        console.log("🔌 QR SSE 연결 해제");
       }
-      clientRef.current = null;
+      eventSourceRef.current = null;
     };
   }, [qrTicketId, handleMessage]); // onMessage 제거, handleMessage 사용
 }

--- a/src/utils/useQrTicketSocket.tsx
+++ b/src/utils/useQrTicketSocket.tsx
@@ -32,7 +32,7 @@ export function useQrTicketSocket(qrTicketId: number, onMessage: (msg: string) =
     });
 
     eventSource.addEventListener("qr-ticket-status", (event) => {
-      handleMessage(event.data);
+      handleMessage((event as MessageEvent).data);
     });
 
     eventSource.onerror = (error) => {
@@ -40,10 +40,8 @@ export function useQrTicketSocket(qrTicketId: number, onMessage: (msg: string) =
     };
 
     return () => {
-      if (eventSourceRef.current) {
-        eventSourceRef.current.close();
-        console.log("🔌 QR SSE 연결 해제");
-      }
+      eventSource.close();
+      console.log("🔌 QR SSE 연결 해제");
       eventSourceRef.current = null;
     };
   }, [qrTicketId, handleMessage]); // onMessage 제거, handleMessage 사용

--- a/src/utils/useWaitingSocket.tsx
+++ b/src/utils/useWaitingSocket.tsx
@@ -33,7 +33,7 @@ export function useWaitingSocket(userId: number, onMessage: (msg: string) => voi
     });
 
     eventSource.addEventListener("waiting-status", (event) => {
-      handleMessage(event.data);
+      handleMessage((event as MessageEvent).data);
     });
 
     eventSource.onerror = (error) => {
@@ -41,10 +41,8 @@ export function useWaitingSocket(userId: number, onMessage: (msg: string) => voi
     };
 
     return () => {
-      if (eventSourceRef.current) {
-        eventSourceRef.current.close();
-        console.log("🔌 웨이팅 SSE 연결 해제");
-      }
+      eventSource.close();
+      console.log("🔌 웨이팅 SSE 연결 해제");
       eventSourceRef.current = null;
     };
   }, [userId, handleMessage]); // onMessage 제거, handleMessage 사용

--- a/src/utils/useWaitingSocket.tsx
+++ b/src/utils/useWaitingSocket.tsx
@@ -1,12 +1,8 @@
 
 import { useEffect, useRef, useCallback } from "react";
-import SockJS from "sockjs-client";
-import Stomp from "stompjs";
-
 
 export function useWaitingSocket(userId: number, onMessage: (msg: string) => void) {
-    const clientRef = useRef<Stomp.Client | null>(null);
-    const subscriptionsRef = useRef<Stomp.Subscription[]>([]);
+    const eventSourceRef = useRef<EventSource | null>(null);
     const onMessageRef = useRef(onMessage);
     
     // onMessage 콜백을 ref에 저장하여 최신 버전 유지
@@ -21,54 +17,35 @@ export function useWaitingSocket(userId: number, onMessage: (msg: string) => voi
   useEffect(() => {
     if (!userId) return;
 
-    // 이미 연결된 상태라면 중복 연결 방지
-    if (clientRef.current && clientRef.current.connected) {
-        console.log("이미 웹소켓이 연결되어 있습니다. 중복 연결을 방지합니다.");
+    if (eventSourceRef.current) {
+        console.log("이미 웨이팅 SSE가 연결되어 있습니다. 중복 연결을 방지합니다.");
         return;
     }
 
-    const sock = new SockJS(`${import.meta.env.VITE_BACKEND_BASE_URL}/ws/waiting-sockjs`);
-    const stomp = Stomp.over(sock);
+    const backendUrl = import.meta.env.VITE_BACKEND_BASE_URL || window.location.origin;
+    const eventSource = new EventSource(`${backendUrl}/api/booth-experiences/waiting/stream`, {
+      withCredentials: true,
+    });
+    eventSourceRef.current = eventSource;
 
-    stomp.debug = () => {}; // 로그 끔
-    clientRef.current = stomp;
+    eventSource.addEventListener("waiting-connected", () => {
+      console.log("🔌 웨이팅 SSE 연결 성공");
+    });
 
-    stomp.connect(
-          {},
-      () => {
-            console.log("🔌 웨이팅 웹소켓 연결 성공, 구독 시작");
+    eventSource.addEventListener("waiting-status", (event) => {
+      handleMessage(event.data);
+    });
 
-            const subWaiting = stomp.subscribe(
-            `/topic/waiting/${userId}`,
-            (message) => {
-                handleMessage(message.body);
-            }
-            );
-        
-            subscriptionsRef.current = [subWaiting];
-      },
-      (err) => {
-        console.error("웨이팅 socket error:", err);
-      }
-    );
+    eventSource.onerror = (error) => {
+      console.error("웨이팅 SSE error:", error);
+    };
 
     return () => {
-      // 두 구독 모두 해제
-      subscriptionsRef.current.forEach((sub) => {
-        try {
-          sub.unsubscribe();
-        } catch (e) {
-          console.warn("구독 해제 중 오류:", e);
-        }
-      });
-      subscriptionsRef.current = [];
-      
-      if (clientRef.current?.connected) {
-        clientRef.current.disconnect(() => {
-          console.log("🔌 QR 웹소켓 연결 해제");
-        });
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close();
+        console.log("🔌 웨이팅 SSE 연결 해제");
       }
-      clientRef.current = null;
+      eventSourceRef.current = null;
     };
   }, [userId, handleMessage]); // onMessage 제거, handleMessage 사용
 }


### PR DESCRIPTION
## Summary
- Replace QR ticket and booth waiting SockJS clients with credentialed EventSource streams.
- Stop the guest QR link page from opening realtime transport.
- Keep existing hook names to minimize call-site churn.

## Verification
- `npm ci`
- `npm run typecheck:changed`
- `npm run lint:changed`
- `npm run route:check`
- `npm run build`
- vendor chunk guard: no `/assets/vendor-` matches in `dist/index.html` or `dist/assets`

## Notes
- Existing build warnings remain non-fatal: stale Browserslist data, stompjs node module externalization from remaining chat code, react-toastify mixed dynamic/static imports, and large main chunk.
- CodeRabbit rate-limit/stale notices are non-blocking per project policy unless they include concrete Critical/High/Important findings.