### PR TITLE
Fix frontend runtime smoke blockers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, lazy, Suspense } from "react";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { useEffect, useState, lazy, Suspense, type ReactNode } from "react";
+import { BrowserRouter, Routes, Route, useNavigate } from "react-router-dom";
 import { useLocation } from "react-router-dom";
 // import axios from "axios";
 // import authManager from "./utils/auth";
@@ -83,7 +83,7 @@ import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import './App.css';
 import { ThemeProvider } from './context/ThemeContext';
-import { AuthProvider } from './context/AuthContext';
+import { AuthProvider, useAuth } from './context/AuthContext';
 
 import KakaoCallback from "./pages/user_auth/KakaoCallback";
 import ChatFloatingModal from "./components/chat/ChatFloatingModal";
@@ -113,6 +113,42 @@ import BoothEdit from "./pages/booth_admin/BoothEdit";
 import CreatorList from "./pages/creators/CreatorList";
 import CreatorDetail from "./pages/creators/CreatorDetail";
 import { CreatorManagement } from "./pages/admin_dashboard/CreatorManagement";
+
+interface UserRouteGuardProps {
+    children: ReactNode;
+}
+
+function RouteGuardFallback() {
+    return (
+        <div className="min-h-screen flex items-center justify-center">
+            <div className="text-center">
+                <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto mb-4"></div>
+                <p className="text-gray-600">권한을 확인하고 있습니다...</p>
+            </div>
+        </div>
+    );
+}
+
+function UserRouteGuard({ children }: UserRouteGuardProps) {
+    const { isAuthenticated, loading } = useAuth();
+    const navigate = useNavigate();
+    const location = useLocation();
+
+    useEffect(() => {
+        if (loading || isAuthenticated) return;
+
+        navigate('/login', {
+            replace: true,
+            state: { from: `${location.pathname}${location.search}` },
+        });
+    }, [isAuthenticated, loading, location.pathname, location.search, navigate]);
+
+    if (loading || !isAuthenticated) {
+        return <RouteGuardFallback />;
+    }
+
+    return <>{children}</>;
+}
 
 function AppContent() {
     const [isTokenValidated, setIsTokenValidated] = useState(false);
@@ -228,24 +264,24 @@ function AppContent() {
                         <Route path="/eventoverview" element={<EventOverview />} />
                         <Route path="/eventdetail/:eventId" element={<EventDetail />} />
                         <Route path="/event/:eventId" element={<EventDetail />} />
-                        <Route path="/ticket-reservation/:eventId" element={<TicketReservation />} />
+                        <Route path="/ticket-reservation/:eventId" element={<UserRouteGuard><TicketReservation /></UserRouteGuard>} />
                         <Route path="/events/:eventId/participating-booths" element={<ParticipatingBooths />} />
                         <Route path="/events/:eventId/booths" element={<BoothList />} />
                         <Route path="/events/:eventId/booths/:boothId" element={<BoothDetail />} />
                         <Route path="/events/:eventId/booth-application" element={<BoothApplication />} />
-                        <Route path="/mypage/info" element={<MyPageInfo />} />
-                        <Route path="/mypage/account" element={<MyPageAccount />} />
-                        <Route path="/mypage/favorites" element={<MyPageFavorites />} />
-                        <Route path="/mypage/reservation" element={<Reservation />} />
-                        <Route path="/mypage/tickets" element={<MyTickets />} />
-                        <Route path="/mypage/participant-form" element={<ParticipantForm />} />
-                        <Route path="/mypage/participant-list" element={<ParticipantList />} />
-                        <Route path="/mypage/write-review" element={<MyPageMyReview />} />
-                        <Route path="/mypage/my-review" element={<MyPageMyReview />} />
-                        <Route path="/mypage/withdrawal" element={<Withdrawal />} />
-                        <Route path="/mypage/refund" element={<RefundList />} />
-                        <Route path="/mypage/business-card" element={<BusinessCard />} />
-                        <Route path="/mypage/business-card-wallet" element={<BusinessCardWallet />} />
+                        <Route path="/mypage/info" element={<UserRouteGuard><MyPageInfo /></UserRouteGuard>} />
+                        <Route path="/mypage/account" element={<UserRouteGuard><MyPageAccount /></UserRouteGuard>} />
+                        <Route path="/mypage/favorites" element={<UserRouteGuard><MyPageFavorites /></UserRouteGuard>} />
+                        <Route path="/mypage/reservation" element={<UserRouteGuard><Reservation /></UserRouteGuard>} />
+                        <Route path="/mypage/tickets" element={<UserRouteGuard><MyTickets /></UserRouteGuard>} />
+                        <Route path="/mypage/participant-form" element={<UserRouteGuard><ParticipantForm /></UserRouteGuard>} />
+                        <Route path="/mypage/participant-list" element={<UserRouteGuard><ParticipantList /></UserRouteGuard>} />
+                        <Route path="/mypage/write-review" element={<UserRouteGuard><MyPageMyReview /></UserRouteGuard>} />
+                        <Route path="/mypage/my-review" element={<UserRouteGuard><MyPageMyReview /></UserRouteGuard>} />
+                        <Route path="/mypage/withdrawal" element={<UserRouteGuard><Withdrawal /></UserRouteGuard>} />
+                        <Route path="/mypage/refund" element={<UserRouteGuard><RefundList /></UserRouteGuard>} />
+                        <Route path="/mypage/business-card" element={<UserRouteGuard><BusinessCard /></UserRouteGuard>} />
+                        <Route path="/mypage/business-card-wallet" element={<UserRouteGuard><BusinessCardWallet /></UserRouteGuard>} />
 
                         {/* 제작자 페이지 */}
                         <Route path="/creators" element={<CreatorList />} />
@@ -353,8 +389,8 @@ function AppContent() {
 
                         {/* 부스 체험 (행사관리자) 라우트 제거됨 */}
                         <Route path="/events/:eventId/booth-experiences" element={<BoothExperienceList />} />
-                        <Route path="/mypage/booth-experiences" element={<BoothExperienceList />} />
-                        <Route path="/mypage/booth-experiences-reservation" element={<MyBoothExperienceReservations />} />
+                        <Route path="/mypage/booth-experiences" element={<UserRouteGuard><BoothExperienceList /></UserRouteGuard>} />
+                        <Route path="/mypage/booth-experiences-reservation" element={<UserRouteGuard><MyBoothExperienceReservations /></UserRouteGuard>} />
                         {/* Footer pages */}
                         <Route path="/support/notices" element={<Notices />} />
                         <Route path="/support/faq" element={<FAQ />} />

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -95,15 +95,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   // 로그아웃 처리 (HTTP-only 쿠키 + Redis 세션 + 로컬스토리지 정리)
   const logout = async (): Promise<void> => {
+    // presence disconnect는 세션 쿠키가 삭제되기 전에 조용히 정리한다.
+    await presenceManager.stopHeartbeat();
+
     try {
       // 서버에 로그아웃 요청 (HTTP-only 쿠키 삭제 + Redis 세션 삭제)
       await api.post('/api/auth/logout');
     } catch (error) {
       console.error('서버 로그아웃 요청 실패:', error);
     }
-
-    // presenceManager heartbeat 중지
-    presenceManager.stopHeartbeat();
 
     // 로컬 상태 초기화
     setIsAuthenticated(false);

--- a/src/pages/OnlyQrTicketErrorPage.tsx
+++ b/src/pages/OnlyQrTicketErrorPage.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useEffect, useRef } from "react";
+import React from "react";
 import { AlertTriangle, X } from "lucide-react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 // 스크롤바 숨기기 CSS
 const scrollbarHideStyles = `
@@ -16,10 +16,23 @@ const scrollbarHideStyles = `
 // 비회원 QR 티켓 조회 페이지
 export const OnlyQrTicketErrorPage = () => {
     const location = useLocation();
-    const { title, message } = location.state;
-    
-    useEffect(() => {
-    }, []);
+    const navigate = useNavigate();
+    const state = location.state as { title?: unknown; message?: unknown } | null;
+    const title = typeof state?.title === "string" ? state.title : "죄송합니다";
+    const message =
+        typeof state?.message === "string"
+            ? state.message
+            : "QR 티켓 정보를 불러올 수 없습니다. 링크를 다시 확인해주세요.";
+
+    const handleClose = () => {
+        if (window.history.length > 1) {
+            navigate(-1);
+            return;
+        }
+
+        navigate("/");
+    };
+
     return (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[9999]">
              <style>{scrollbarHideStyles}</style>
@@ -31,10 +44,25 @@ export const OnlyQrTicketErrorPage = () => {
                             {title}
                         </h3>
                     </div>
+                    <button
+                        type="button"
+                        onClick={handleClose}
+                        aria-label="닫기"
+                        className="text-gray-400 hover:text-gray-600 transition-colors"
+                    >
+                        <X className="w-5 h-5" />
+                    </button>
                 </div>
                 <p className="[font-family:'Roboto-Regular',Helvetica] font-normal text-gray-700 text-base leading-6 mb-6">
                     {message}
                 </p>
+                <button
+                    type="button"
+                    onClick={handleClose}
+                    className="w-full px-4 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors"
+                >
+                    닫기
+                </button>
             </div>
         </div>
     );

--- a/src/pages/user_event/EventDetail.tsx
+++ b/src/pages/user_event/EventDetail.tsx
@@ -2,11 +2,8 @@ import React, {useState, useEffect} from "react";
 import {useParams, useNavigate, useLocation} from "react-router-dom";
 import {TopNav} from "../../components/TopNav";
 import {MapPin} from "lucide-react";
-import {FaHeart} from "react-icons/fa";
-import {requireAuth} from "../../utils/authGuard";
 import {useAuth} from "../../context/AuthContext";
 import {VenueInfo} from "./VenueInfo";
-import {CancelPolicy} from "./CancelPolicy";
 import {Reviews} from "./Reviews";
 import {Expectations} from "./Expectations";
 import {ParticipatingBooths} from "./ParticipatingBooths";
@@ -26,11 +23,12 @@ import {
 
 type WishlistResponseDto = { eventId: number };
 
-import authManager from "../../utils/auth";
 import {toast} from 'react-toastify';
 import NewLoader from "../../components/NewLoader";
 import {useScrollToTop} from "../../hooks/useScrollToTop";
 import HeartBox from "../../components/Heart";
+
+const EVENT_IMAGE_FALLBACK_SRC = "/images/NoImage.png";
 
 // 회차 정보 인터페이스
 interface EventSchedule {
@@ -47,6 +45,22 @@ interface EventSchedule {
 const authHeaders = () => ({});
 
 // 인증 상태는 useAuth 훅으로 확인 (컴포넌트 내부에서 isAuthenticated 사용)
+type TicketPrice = { name: string; price: number };
+type EventScheduleResponse = {
+    scheduleId: number;
+    date: string;
+    startTime: string;
+    endTime: string;
+    weekday: number;
+    hasActiveTickets?: boolean;
+    soldTicketCount?: number;
+};
+type TicketResponse = {
+    name?: string;
+    ticketName?: string;
+    title?: string;
+    price?: number;
+};
 
 const EventDetail = (): JSX.Element => {
     const {setAutoScrolling} = useScrollToTop();
@@ -55,6 +69,7 @@ const EventDetail = (): JSX.Element => {
     const {isAuthenticated} = useAuth();
     const [eventData, setEventData] = useState<EventDetailResponseDto | null>(null);
     const [loading, setLoading] = useState(true);
+    const [failedImageUrls, setFailedImageUrls] = useState<Set<string>>(() => new Set());
 
     const [currentCalendarYear, setCurrentCalendarYear] = useState<number>(2025);
     const [currentCalendarMonth, setCurrentCalendarMonth] = useState<number>(7);
@@ -64,7 +79,7 @@ const EventDetail = (): JSX.Element => {
     const [availableSchedules, setAvailableSchedules] = useState<EventSchedule[]>([]); // 선택된 날짜의 회차 목록
     const [allSchedules, setAllSchedules] = useState<EventSchedule[]>([]); // 전체 회차 목록
     const [selectedScheduleId, setSelectedScheduleId] = useState<number | null>(null); // 선택된 회차 ID
-    const [ticketPrices, setTicketPrices] = useState<{ name: string, price: number }[]>([]); // 티켓 가격 목록
+    const [ticketPrices, setTicketPrices] = useState<TicketPrice[]>([]); // 티켓 가격 목록
     const [isExternalBookingOpen, setIsExternalBookingOpen] = useState(false);
     const [reviews, setReviews] = useState<ReviewForEventResponseDto | null>(null)
     const [currentPage, setCurrentPage] = useState(0);
@@ -145,99 +160,6 @@ const EventDetail = (): JSX.Element => {
         }
     };
 
-    // 이벤트 데이터 로드 시 달력 초기화
-    // useEffect(() => {
-    //     if (eventData) {
-    //         const eventDates = parseEventDates(eventData.schedule);
-    //         if (eventDates) {
-    //             setCurrentCalendarYear(eventDates.startYear);
-    //             setCurrentCalendarMonth(eventDates.startMonth);
-    //         }
-    //     }
-    // }, [eventData]);
-
-    // 날짜 파싱 함수
-
-
-    const parseEventDates = (schedule: string) => {
-        // "2025.07.26 - 2025.07.27 11:00" 형식에서 날짜 추출
-        const dateMatches = schedule.match(/(\d{4})\.(\d{2})\.(\d{2})/g);
-        if (dateMatches && dateMatches.length >= 2) {
-            const startDate = dateMatches[0].split('.').map(Number);
-            const endDate = dateMatches[1].split('.').map(Number);
-
-            return {
-                startYear: startDate[0],
-                startMonth: startDate[1],
-                startDay: startDate[2],
-                endYear: endDate[0],
-                endMonth: endDate[1],
-                endDay: endDate[2]
-            };
-        }
-        return null;
-    };
-
-    // 달력 네비게이션 함수들
-    const handlePrevMonth = () => {
-        if (currentCalendarMonth === 1) {
-            setCurrentCalendarYear(currentCalendarYear - 1);
-            setCurrentCalendarMonth(12);
-        } else {
-            setCurrentCalendarMonth(currentCalendarMonth - 1);
-        }
-    };
-
-    const handleNextMonth = () => {
-        if (currentCalendarMonth === 12) {
-            setCurrentCalendarYear(currentCalendarYear + 1);
-            setCurrentCalendarMonth(1);
-        } else {
-            setCurrentCalendarMonth(currentCalendarMonth + 1);
-        }
-    };
-
-    // 달력 생성 함수
-    const generateCalendar = (year: number, month: number) => {
-        const firstDay = new Date(year, month - 1, 1).getDay();
-        const daysInMonth = new Date(year, month, 0).getDate();
-        const calendar = [];
-
-        // 이전 달의 마지막 날짜들
-        const prevMonth = month === 1 ? 12 : month - 1;
-        const prevYear = month === 1 ? year - 1 : year;
-        const daysInPrevMonth = new Date(prevYear, prevMonth, 0).getDate();
-
-        for (let i = firstDay - 1; i >= 0; i--) {
-            calendar.push({
-                day: daysInPrevMonth - i,
-                isCurrentMonth: false,
-                isEventDay: false
-            });
-        }
-
-        // 현재 달의 날짜들
-        for (let day = 1; day <= daysInMonth; day++) {
-            calendar.push({
-                day,
-                isCurrentMonth: true,
-                isEventDay: false
-            });
-        }
-
-        // 다음 달의 날짜들 (6주 완성)
-        const remainingDays = 42 - calendar.length;
-        for (let day = 1; day <= remainingDays; day++) {
-            calendar.push({
-                day,
-                isCurrentMonth: false,
-                isEventDay: false
-            });
-        }
-
-        return calendar;
-    };
-
     // 이벤트 데이터 로드 (실제로는 API 호출)
     useEffect(() => {
         const loadEventData = async () => {
@@ -309,11 +231,11 @@ const EventDetail = (): JSX.Element => {
             console.log('전체 회차 조회 시도...');
             const response = await api.get(`/api/events/${eventId}/schedule`);
 
-            const scheduleList = response.data;
+            const scheduleList: EventScheduleResponse[] = response.data;
             console.log('API로부터 받은 전체 회차 목록:', scheduleList);
 
             // 전체 회차 데이터 포맷팅
-            const formattedSchedules = scheduleList.map((schedule: any) => ({
+            const formattedSchedules = scheduleList.map((schedule) => ({
                 scheduleId: schedule.scheduleId,
                 date: schedule.date,
                 startTime: schedule.startTime,
@@ -348,29 +270,6 @@ const EventDetail = (): JSX.Element => {
         }
 
         console.log(`${date} 날짜의 회차:`, dateSchedules);
-    };
-
-    // 목업 회차 데이터 생성 함수 (단일 날짜)
-    const generateMockSchedules = (date: string) => {
-        const schedules = [];
-        const times = [
-            {start: '14:00', end: '16:00'},
-            {start: '19:00', end: '21:00'}
-        ];
-
-        times.forEach((time, index) => {
-            schedules.push({
-                scheduleId: index + 1,
-                date: date,
-                startTime: time.start,
-                endTime: time.end,
-                weekday: new Date(date + 'T00:00:00').getDay(),
-                hasActiveTickets: true,
-                soldTicketCount: Math.floor(Math.random() * 50)
-            });
-        });
-
-        return schedules;
     };
 
     // 전체 날짜에 대한 목업 회차 데이터 생성 함수
@@ -424,13 +323,13 @@ const EventDetail = (): JSX.Element => {
             }
 
             // 티켓 가격 목록 생성
-            const priceList = ticketList.map((ticket: any) => {
+            const priceList: TicketPrice[] = ticketList.map((ticket: TicketResponse) => {
                 console.log('개별 티켓 데이터:', ticket);
                 return {
                     name: ticket.name || ticket.ticketName || ticket.title || '이름 없음',
                     price: ticket.price || 0
                 };
-            }).sort((a, b) => b.price - a.price); // 가격 높은 순으로 정렬
+            }).sort((a: TicketPrice, b: TicketPrice) => b.price - a.price); // 가격 높은 순으로 정렬
 
             setTicketPrices(priceList);
             console.log('이벤트 티켓 가격 목록:', priceList);
@@ -530,38 +429,6 @@ const EventDetail = (): JSX.Element => {
         }, 100);
     };
 
-    // 회차 선택 핸들러
-    const handleScheduleSelect = (scheduleId: number) => {
-        setSelectedScheduleId(scheduleId);
-
-        // 선택된 날짜가 있으면 해당 날짜로 자동 스크롤
-        if (selectedDate) {
-            // 자동 스크롤 시작
-            setAutoScrolling(true);
-
-            setTimeout(() => {
-                const selectedDateElement = document.querySelector(`[data-date="${selectedDate}"]`);
-                if (selectedDateElement) {
-                    const container = selectedDateElement.closest('.max-h-60');
-                    if (container) {
-                        selectedDateElement.scrollIntoView({
-                            behavior: 'smooth',
-                            block: 'center',
-                            inline: 'nearest'
-                        });
-                    }
-                }
-                // 자동 스크롤 완료 후 상태 해제
-                setTimeout(() => setAutoScrolling(false), 500);
-            }, 100);
-        }
-    };
-
-    // 선택된 회차 정보 가져오기
-    const getSelectedSchedule = () => {
-        return availableSchedules.find(schedule => schedule.scheduleId === selectedScheduleId);
-    };
-
     // 현재 날짜(오늘) 가져오기
     const getTodayDateString = () => {
         const today = new Date();
@@ -596,6 +463,27 @@ const EventDetail = (): JSX.Element => {
         return dateSchedules.some(schedule => schedule.hasActiveTickets);
     };
 
+    const getImageSrc = (src?: string | null) => (
+        src && !failedImageUrls.has(src) ? src : EVENT_IMAGE_FALLBACK_SRC
+    );
+
+    const handleImageError = (
+        event: React.SyntheticEvent<HTMLImageElement>,
+        originalSrc?: string | null
+    ) => {
+        event.currentTarget.onerror = null;
+        event.currentTarget.src = EVENT_IMAGE_FALLBACK_SRC;
+
+        if (originalSrc) {
+            setFailedImageUrls((prev) => {
+                if (prev.has(originalSrc)) return prev;
+                const next = new Set(prev);
+                next.add(originalSrc);
+                return next;
+            });
+        }
+    };
+
     if (loading) {
         return (
             <div className="min-h-screen bg-white flex items-center justify-center">
@@ -622,9 +510,10 @@ const EventDetail = (): JSX.Element => {
                 <div className="flex flex-col lg:flex-row gap-4 md:gap-8">
                     <div className="relative w-full lg:w-auto">
                         <img
-                            src={eventData.thumbnailUrl}
+                            src={getImageSrc(eventData.thumbnailUrl)}
                             alt={eventData.titleKr}
                             className="w-full max-w-[438px] h-auto max-h-[526px] object-cover mx-auto lg:mx-0"
+                            onError={(event) => handleImageError(event, eventData.thumbnailUrl)}
                         />
                     </div>
 
@@ -952,9 +841,6 @@ const EventDetail = (): JSX.Element => {
                                                 const isPastDate = !isDateInFuture(date);
                                                 const dateObj = new Date(date + 'T00:00:00');
                                                 const dayName = ['일', '월', '화', '수', '목', '금', '토'][dateObj.getDay()];
-
-                                                // 선택된 날짜의 경우 해당 회차 정보 가져오기
-                                                const schedulesForDate = isSelected ? availableSchedules : [];
 
                                                 return (
                                                     <div

--- a/src/pages/user_event/ParticipatingBooths.tsx
+++ b/src/pages/user_event/ParticipatingBooths.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useMemo } from "react";
+import React, { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { getBooths, getBoothDetails, applyForBooth, getBoothTypes } from "../../api/boothApi";
 import {BoothDetailResponse, BoothSummary, BoothType} from "../../types/booth";
 import { eventAPI } from "../../services/event";
@@ -7,19 +7,9 @@ import { useFileUpload } from "../../hooks/useFileUpload";
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 
-interface Booth {
-    id: number;
-    name: string;
-    company: string;
-    category: string;
-    description: string;
-    location: string;
-    contactEmail: string;
-    contactPhone: string;
-    website?: string;
-    logoUrl?: string;
-    isActive: boolean;
-}
+const BOOTH_IMAGE_FALLBACK_SRC = "/images/NoImage.png";
+
+type UploadedEditorImage = { url?: string | null };
 
 interface ParticipatingBoothsProps {
     eventId?: string;
@@ -28,48 +18,48 @@ interface ParticipatingBoothsProps {
 export const ParticipatingBooths: React.FC<ParticipatingBoothsProps> = ({ eventId }) => {
     const [booths, setBooths] = useState<BoothSummary[]>([]);
     const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
     const [searchTerm, setSearchTerm] = useState("");
     const [selectedBooth, setSelectedBooth] = useState<BoothDetailResponse | null>(null);
     const [showApplicationForm, setShowApplicationForm] = useState(false);
     const [boothTypes, setBoothTypes] = useState<BoothType[]>([]);
     const [eventDetail, setEventDetail] = useState<EventDetailResponseDto | null>(null);
+    const [failedImageUrls, setFailedImageUrls] = useState<Set<string>>(() => new Set());
     
     // 파일 업로드 훅
-    const { uploadFile, getFileByUsage, removeFile, getFileUploadDtos, isUploading } = useFileUpload();
+    const { uploadFile, getFileByUsage, removeFile, isUploading } = useFileUpload();
     
     // ReactQuill 참조
     const quillRef = useRef<ReactQuill>(null);
     
     // 파일 선택
-    const pickImageFile = () =>
+    const pickImageFile = useCallback(() =>
         new Promise<File | null>((resolve) => {
             const input = document.createElement("input");
             input.type = "file";
             input.accept = "image/*";
             input.onchange = () => resolve(input.files?.[0] || null);
             input.click();
-        });
+        }), []);
 
     // 이미지 삽입
-    const insertImage = (url: string) => {
+    const insertImage = useCallback((url: string) => {
         const quill = quillRef.current?.getEditor();
         if (!quill) return;
         const range = quill.getSelection(true) ?? { index: quill.getLength(), length: 0 };
         quill.insertEmbed(range.index, "image", url, "user");
         quill.setSelection(range.index + 1, 0, "user");
-    };
+    }, []);
 
     // 서버 업로드 → CDN URL
-    const uploadEditorImageAndGetUrl = async (file: File) => {
+    const uploadEditorImageAndGetUrl = useCallback(async (file: File) => {
         try {
-            const uploaded: any = await uploadFile(file, "editor_image");
+            const uploaded = await uploadFile(file, "editor_image") as UploadedEditorImage | null;
             return uploaded?.url || null;
         } catch (error) {
             console.error("이미지 업로드 실패:", error);
             return null;
         }
-    };
+    }, [uploadFile]);
 
     // 에디터 모듈 설정
     const editorModules = useMemo(() => ({
@@ -92,7 +82,7 @@ export const ParticipatingBooths: React.FC<ParticipatingBoothsProps> = ({ eventI
         },
         clipboard: { matchVisual: false },
         history: { delay: 1000, maxStack: 100, userOnly: true },
-    }), []);
+    }), [insertImage, pickImageFile, uploadEditorImageAndGetUrl]);
 
     const quillFormats = [
         "header", "bold", "italic", "underline", "strike",
@@ -135,14 +125,6 @@ export const ParticipatingBooths: React.FC<ParticipatingBoothsProps> = ({ eventI
     const handleFileRemove = (usage: string) => {
         removeFile(usage);
     };
-
-    // 이미지 업로드 핸들러 (에디터용)
-    const handleImageUpload = async (file: File): Promise<string | null> => {
-        const response = await uploadFile(file, `description_image_${Date.now()}`);
-        return response ? response.url : null;
-    };
-
-
 
     // 목업 부스 데이터
     // const mockBooths: Booth[] = [
@@ -268,7 +250,6 @@ export const ParticipatingBooths: React.FC<ParticipatingBoothsProps> = ({ eventI
                 setEventDetail(eventDetailData);
             } catch (error) {
                 console.error('데이터 로드 실패:', error);
-                setError('데이터를 불러오는 데 실패했습니다.');
             } finally {
                 setLoading(false);
             }
@@ -282,6 +263,27 @@ export const ParticipatingBooths: React.FC<ParticipatingBoothsProps> = ({ eventI
         const matchesSearch = booth.boothTitle.toLowerCase().includes(searchTerm.toLowerCase());
         return matchesSearch;
     });
+
+    const getImageSrc = (src?: string | null) => (
+        src && !failedImageUrls.has(src) ? src : BOOTH_IMAGE_FALLBACK_SRC
+    );
+
+    const handleImageError = (
+        event: React.SyntheticEvent<HTMLImageElement>,
+        originalSrc?: string | null
+    ) => {
+        event.currentTarget.onerror = null;
+        event.currentTarget.src = BOOTH_IMAGE_FALLBACK_SRC;
+
+        if (originalSrc) {
+            setFailedImageUrls((prev) => {
+                if (prev.has(originalSrc)) return prev;
+                const next = new Set(prev);
+                next.add(originalSrc);
+                return next;
+            });
+        }
+    };
 
     // 부스 클릭 핸들러
     const handleBoothClick = async (booth: BoothSummary) => {
@@ -304,7 +306,6 @@ export const ParticipatingBooths: React.FC<ParticipatingBoothsProps> = ({ eventI
             }, 100);
         } catch (error) {
             console.error('부스 상세 정보 불러오기 실패:', error);
-            setError('부스 상세 정보를 불러오는 데 실패했습니다.');
         }
     };
 
@@ -401,8 +402,6 @@ export const ParticipatingBooths: React.FC<ParticipatingBoothsProps> = ({ eventI
         try {
             setLoading(true);
             
-            // 부스 신청 데이터 생성
-            const uploadedFiles = getFileUploadDtos();
             const bannerFile = getFileByUsage('banner');
             
             const applicationData = {
@@ -486,9 +485,10 @@ export const ParticipatingBooths: React.FC<ParticipatingBoothsProps> = ({ eventI
                                 <div className="aspect-square bg-gray-100 rounded-lg flex items-center justify-center">
                                     {selectedBooth.boothBannerUrl ? (
                                         <img
-                                            src={selectedBooth.boothBannerUrl}
+                                            src={getImageSrc(selectedBooth.boothBannerUrl)}
                                             alt={selectedBooth.boothTitle}
                                             className="w-full h-full object-cover rounded-lg"
+                                            onError={(event) => handleImageError(event, selectedBooth.boothBannerUrl)}
                                         />
                                     ) : (
                                         <div className="text-gray-400 text-center">
@@ -1002,9 +1002,10 @@ export const ParticipatingBooths: React.FC<ParticipatingBoothsProps> = ({ eventI
                                 <div className="aspect-square bg-gray-100 rounded-t-[10px] flex items-center justify-center">
                                     {booth.boothBannerUrl ? (
                                         <img
-                                            src={booth.boothBannerUrl}
+                                            src={getImageSrc(booth.boothBannerUrl)}
                                             alt={booth.boothTitle}
                                             className="w-full h-full object-cover rounded-t-[10px]"
+                                            onError={(event) => handleImageError(event, booth.boothBannerUrl)}
                                         />
                                     ) : (
                                         <div className="text-gray-400 text-center">

--- a/src/utils/presenceManager.ts
+++ b/src/utils/presenceManager.ts
@@ -5,7 +5,19 @@
 class PresenceManager {
     private heartbeatInterval: NodeJS.Timeout | null = null;
     private isActive = false;
-    private isAuthenticated = true; // 세션 유효 상태 (401 발생 시 false로 변경)
+    private isAuthenticated = false; // 세션 유효 상태 (401/403 발생 시 false로 변경)
+    private hasConnectedSession = false;
+    private heartbeatSequence = 0;
+    private isInitialized = false;
+    private readonly handleBeforeUnload = () => {
+        void this.stopHeartbeat();
+    };
+    private readonly handlePageHide = () => {
+        void this.stopHeartbeat();
+    };
+    private readonly handleVisibility = () => {
+        this.handleVisibilityChange();
+    };
 
     /**
      * 온라인 상태 heartbeat 시작
@@ -15,19 +27,20 @@ class PresenceManager {
             return;
         }
 
+        const sequence = ++this.heartbeatSequence;
         this.isActive = true;
         this.isAuthenticated = true; // 시작 시 인증된 것으로 가정
         console.log('🔄 온라인 상태 heartbeat 시작 (HTTP-only 쿠키 기반)');
 
         // 즉시 한 번 실행
-        this.sendHeartbeat();
+        void this.sendHeartbeat(sequence);
 
         // 2분마다 heartbeat 전송 (Redis TTL이 5분이므로)
         this.heartbeatInterval = setInterval(() => {
             if (this.isActive && this.isAuthenticated) {
-                this.sendHeartbeat();
+                void this.sendHeartbeat(sequence);
             } else {
-                this.stopHeartbeat();
+                void this.stopHeartbeat();
             }
         }, 120000); // 2분
     }
@@ -35,24 +48,28 @@ class PresenceManager {
     /**
      * 온라인 상태 heartbeat 중지
      */
-    stopHeartbeat() {
+    async stopHeartbeat() {
+        const shouldDisconnect = this.isAuthenticated && this.hasConnectedSession;
+        this.heartbeatSequence += 1;
+        this.hasConnectedSession = false;
+
         if (this.heartbeatInterval) {
             clearInterval(this.heartbeatInterval);
             this.heartbeatInterval = null;
-            this.isActive = false;
             console.log('⏹️ 온라인 상태 heartbeat 중지');
         }
+        this.isActive = false;
 
-        // 오프라인 상태로 설정
-        if (this.isAuthenticated) {
-            this.sendDisconnect();
+        // 실제 heartbeat 연결이 성립된 세션만 오프라인 상태로 설정
+        if (shouldDisconnect) {
+            await this.sendDisconnect();
         }
     }
 
     /**
      * heartbeat 전송 (HTTP-only 쿠키 기반)
      */
-    private async sendHeartbeat() {
+    private async sendHeartbeat(sequence: number) {
         try {
             const response = await fetch('/api/chat/presence/connect', {
                 method: 'POST',
@@ -65,10 +82,15 @@ class PresenceManager {
             if (response.status === 401 || response.status === 403) {
                 console.warn('🚫 Heartbeat: 인증 실패 (세션 만료), heartbeat 중단');
                 this.isAuthenticated = false;
-                this.stopHeartbeat();
+                this.hasConnectedSession = false;
+                await this.stopHeartbeat();
                 // 401 이벤트 발생 (AuthContext가 자동 로그아웃 처리)
                 window.dispatchEvent(new CustomEvent('auth:unauthorized'));
                 return;
+            }
+
+            if (response.ok && sequence === this.heartbeatSequence && this.isActive) {
+                this.hasConnectedSession = true;
             }
 
             console.log('💓 Heartbeat 전송 완료 (HTTP-only 쿠키)');
@@ -82,16 +104,25 @@ class PresenceManager {
      */
     private async sendDisconnect() {
         try {
-            await fetch('/api/chat/presence/disconnect', {
+            const response = await fetch('/api/chat/presence/disconnect', {
                 method: 'POST',
                 credentials: 'include', // HTTP-only 쿠키 자동 전송
+                keepalive: true,
                 headers: {
                     'Content-Type': 'application/json'
                 }
             });
 
+            if (response.status === 401 || response.status === 403) {
+                this.isAuthenticated = false;
+                return;
+            }
+
             console.log('🔴 연결 해제 신호 전송 완료 (HTTP-only 쿠키)');
         } catch (error) {
+            if (error instanceof DOMException && error.name === 'AbortError') {
+                return;
+            }
             console.error('❌ 연결 해제 신호 전송 실패:', error);
         }
     }
@@ -119,30 +150,33 @@ class PresenceManager {
      * AuthContext에서 isAuthenticated가 true일 때만 startHeartbeat()를 호출하세요.
      */
     initialize() {
+        if (this.isInitialized) {
+            return;
+        }
+
+        this.isInitialized = true;
         // ❌ 무조건 heartbeat 시작하지 않음 (AuthContext가 인증 상태 확인 후 시작)
         // this.startHeartbeat();
 
         // 페이지 visibility 변경 감지
-        document.addEventListener('visibilitychange', () => {
-            this.handleVisibilityChange();
-        });
+        document.addEventListener('visibilitychange', this.handleVisibility);
 
         // 브라우저 종료 시 연결 해제
-        window.addEventListener('beforeunload', () => {
-            this.stopHeartbeat();
-        });
+        window.addEventListener('beforeunload', this.handleBeforeUnload);
 
         // 페이지 이동 시 연결 해제
-        window.addEventListener('pagehide', () => {
-            this.stopHeartbeat();
-        });
+        window.addEventListener('pagehide', this.handlePageHide);
     }
 
     /**
      * 정리 (컴포넌트 unmount 시)
      */
     cleanup() {
-        this.stopHeartbeat();
+        document.removeEventListener('visibilitychange', this.handleVisibility);
+        window.removeEventListener('beforeunload', this.handleBeforeUnload);
+        window.removeEventListener('pagehide', this.handlePageHide);
+        this.isInitialized = false;
+        void this.stopHeartbeat();
     }
 }
 


### PR DESCRIPTION
## Summary
- guard QR ticket error route against missing navigation state
- stop unauthenticated presence disconnect calls from public navigation
- gate user-only reservation and mypage routes before protected API calls render
- add local image fallbacks for stale event/booth image URLs

## CI/root cause note
- Historical frontend CI failures were real lint/typecheck gate failures, not runner infra. Current develop script uses Node 22, changed-file typecheck filtering for external diagnostics, route guard check, build, and vendor asset guard.
- CodeRabbit pending/rate-limit states are non-blocking per project instruction; concrete Critical/High/Important review comments remain blockers.

## Verification
- npm run typecheck:changed
- npm run lint:changed
- npm run route:check
- npm run build
- vendor asset guard grep

## Playwright context
- Initial 5-lane live smoke found these blockers before this PR: QR error direct crash, public presence disconnect 401 noise, unauth protected route rendering/JSON 401, broken external event images.
- Full live Playwright re-run will run after develop merge/deploy refresh.

Co-authored-by: OmX <omx@oh-my-codex.dev>