### PR TITLE
Clean authenticated admin smoke client errors

### DIFF
--- a/src/hooks/useNotificationSse.ts
+++ b/src/hooks/useNotificationSse.ts
@@ -21,6 +21,7 @@ export function useNotificationSse() {
   const { isAuthenticated, loading } = useAuth();
   const eventSourceRef = useRef<EventSource | null>(null);
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const closingRef = useRef(false);
   const reconnectAttempts = useRef(0);
   const maxReconnectAttempts = 5;
   const reconnectDelay = 3000;
@@ -91,6 +92,7 @@ export function useNotificationSse() {
     }
 
     console.log("✅ SSE 연결 시작...");
+    closingRef.current = false;
 
     // SSE 엔드포인트 URL (HTTP-only 쿠키 자동 전송)
     const sseUrl = `${import.meta.env.VITE_BACKEND_BASE_URL}/api/notifications/stream`;
@@ -164,7 +166,11 @@ export function useNotificationSse() {
 
     // 에러 처리 및 자동 재연결
     eventSource.onerror = (error) => {
-      console.error("❌ SSE 연결 에러:", error);
+      if (closingRef.current || eventSource.readyState === EventSource.CLOSED) {
+        console.debug("SSE 연결 종료 감지");
+      } else {
+        console.error("❌ SSE 연결 에러:", error);
+      }
       setIsConnected(false);
 
       // EventSource는 자동으로 재연결 시도하지만,
@@ -196,6 +202,7 @@ export function useNotificationSse() {
 
     if (eventSourceRef.current) {
       console.log("🔌 SSE 연결 종료");
+      closingRef.current = true;
       eventSourceRef.current.close();
       eventSourceRef.current = null;
       setIsConnected(false);

--- a/src/pages/admin_vip_banner/AdvertisementApplicationList.tsx
+++ b/src/pages/admin_vip_banner/AdvertisementApplicationList.tsx
@@ -1,4 +1,5 @@
-import React, {useEffect, useMemo, useState} from 'react';
+import React, {useEffect, useState} from 'react';
+import axios from 'axios';
 import api from '../../api/axios'; // HTTP-only 쿠키 기반 인증
 import {TopNav} from '../../components/TopNav';
 import {AdminSideNav} from '../../components/AdminSideNav';
@@ -62,9 +63,6 @@ const AdvertisementApplicationList: React.FC = () => {
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
-
-//백엔드 베이스 URL
-    const BASE_URL = useMemo(() => import.meta.env.VITE_API_BASE_URL ?? 'https://fair-play.ink', []);
     // HTTP-only 쿠키 기반 인증 - withCredentials로 자동 전송됨
 
     const [filterStatus, setFilterStatus] = useState<string>('all');
@@ -143,7 +141,7 @@ const AdvertisementApplicationList: React.FC = () => {
             const mapped = content.map(mapBackendItem);
             setApplications(mapped);
         } catch (e: unknown) {
-            if (api.isAxiosError<{ message?: string }>(e)) {
+            if (axios.isAxiosError<{ message?: string }>(e)) {
                 const apiMsg = e.response?.data?.message ?? e.message;
                 setError(apiMsg || '목록 조회 실패');
             } else {
@@ -230,14 +228,6 @@ const AdvertisementApplicationList: React.FC = () => {
                 return 600000;
         }
     };
-
-
-    // 메인 배너 총액 계산 (선택 매핑)
-    const calculateMainBannerTotalFromSelections = (selections: { date: string; rank: string }[]) => {
-        return selections.reduce((total, sel) => total + getMainBannerPrice(sel.rank), 0);
-    };
-
-
     // 승인/반려 → 백엔드 호출
     const handleStatusChange = async (id: string, newStatus: 'approved' | 'rejected') => {
         // 상태에 따른 확인창 표시
@@ -294,7 +284,7 @@ const AdvertisementApplicationList: React.FC = () => {
         } catch (err: unknown) {
             console.error('API 호출 에러:', err);
 
-            if (api.isAxiosError<{ message?: string }>(err)) {
+            if (axios.isAxiosError<{ message?: string }>(err)) {
                 const code = err.response?.status;
                 const msg =
                     err.response?.data?.message ??

--- a/src/utils/presenceManager.ts
+++ b/src/utils/presenceManager.ts
@@ -120,11 +120,18 @@ class PresenceManager {
 
             console.log('🔴 연결 해제 신호 전송 완료 (HTTP-only 쿠키)');
         } catch (error) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
+            if (this.isExpectedUnloadAbort(error)) {
                 return;
             }
             console.error('❌ 연결 해제 신호 전송 실패:', error);
         }
+    }
+
+    private isExpectedUnloadAbort(error: unknown) {
+        if (!error) return false;
+        if (error instanceof DOMException && error.name === 'AbortError') return true;
+        const message = error instanceof Error ? error.message : String(error);
+        return /abort|failed to fetch|networkerror/i.test(message);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Use axios.isAxiosError on the ad application admin page
- Suppress expected SSE/presence cleanup noise during document navigation
- Remove stale unused code that failed changed-file lint

## Verification
- npm run typecheck:changed
- npm run lint:changed
- npm run route:check
- npm run build