### PR TITLE
Promote auth session and CDN cleanup to main

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -11,6 +11,11 @@ interface User {
   role?: string;
 }
 
+interface AuthSessionResponse {
+  authenticated: boolean;
+  user?: User | null;
+}
+
 interface AuthContextType {
   isAuthenticated: boolean;
   user: User | null;
@@ -32,16 +37,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // 서버에서 사용자 정보 가져오기 (HTTP-only 쿠키 자동 전송)
   const fetchUserInfo = async (): Promise<User | null> => {
     try {
-      const response = await api.get('/api/users/mypage', {
+      const response = await api.get<AuthSessionResponse>('/api/auth/session', {
         headers: { 'X-Silent-Auth': 'true' }
       });
-      
-      if (response.data && response.data.userId) {
+      const userData = response.data.user;
+
+      if (response.data.authenticated && userData?.userId) {
         return {
-          userId: response.data.userId,
-          email: response.data.email || '',
-          name: response.data.name || '',
-          role: response.data.role
+          userId: userData.userId,
+          email: userData.email || '',
+          name: userData.name || '',
+          role: userData.role
         };
       }
       return null;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,9 +9,29 @@ export const getCdnImageUrl = (imagePath: string): string => {
   
   // EC2 Static 서빙 URL
   const staticBaseUrl = import.meta.env.VITE_CDN_BASE_URL || 'https://fair-play.ink/uploads';
+  const normalizedStaticBaseUrl = staticBaseUrl.replace(/\/+$/, '');
+
+  const appendUploadKey = (path: string): string => {
+    const cleanPath = path.replace(/^\/+/, '');
+    if (cleanPath.startsWith('uploads/')) {
+      const uploadKey = normalizedStaticBaseUrl.endsWith('/uploads')
+        ? cleanPath.slice('uploads/'.length)
+        : cleanPath;
+      return `${normalizedStaticBaseUrl}/${uploadKey}`;
+    }
+    return `${normalizedStaticBaseUrl}/${cleanPath}`;
+  };
   
   // 이미 완전한 URL인 경우 그대로 반환
   if (imagePath.startsWith('http://') || imagePath.startsWith('https://')) {
+    try {
+      const url = new URL(imagePath);
+      if (url.hostname === 'd3lmalqtze27ii.cloudfront.net') {
+        return appendUploadKey(url.pathname);
+      }
+    } catch {
+      return imagePath;
+    }
     return imagePath;
   }
   
@@ -27,12 +47,12 @@ export const getCdnImageUrl = (imagePath: string): string => {
   
   // uploads/ 경로인 경우 Static URL 생성
   if (imagePath.startsWith('uploads/')) {
-    return `${staticBaseUrl}/${imagePath}`;
+    return appendUploadKey(imagePath);
   }
   
   // Static URL 생성
   const cleanPath = imagePath.startsWith('/') ? imagePath : `/${imagePath}`;
-  return `${staticBaseUrl}${cleanPath}`;
+  return `${normalizedStaticBaseUrl}${cleanPath}`;
 };
 
 /**

--- a/src/pages/user_event/EventDetail.tsx
+++ b/src/pages/user_event/EventDetail.tsx
@@ -12,6 +12,7 @@ import {eventAPI} from "../../services/event";
 import type {EventDetailResponseDto} from "../../services/types/eventType";
 import {getEventStatusText, getEventStatusStyle} from "../../utils/eventStatus";
 import api from "../../api/axios";
+import {getCdnImageUrl} from "../../lib/utils";
 import {openChatRoomGlobal} from "../../components/chat/ChatFloatingModal";
 import type {
     PageableRequest,
@@ -463,9 +464,10 @@ const EventDetail = (): JSX.Element => {
         return dateSchedules.some(schedule => schedule.hasActiveTickets);
     };
 
-    const getImageSrc = (src?: string | null) => (
-        src && !failedImageUrls.has(src) ? src : EVENT_IMAGE_FALLBACK_SRC
-    );
+    const getImageSrc = (src?: string | null) => {
+        if (!src || failedImageUrls.has(src)) return EVENT_IMAGE_FALLBACK_SRC;
+        return getCdnImageUrl(src);
+    };
 
     const handleImageError = (
         event: React.SyntheticEvent<HTMLImageElement>,

--- a/src/pages/user_event/ParticipatingBooths.tsx
+++ b/src/pages/user_event/ParticipatingBooths.tsx
@@ -4,6 +4,7 @@ import {BoothDetailResponse, BoothSummary, BoothType} from "../../types/booth";
 import { eventAPI } from "../../services/event";
 import type { EventDetailResponseDto } from "../../services/types/eventType";
 import { useFileUpload } from "../../hooks/useFileUpload";
+import { getCdnImageUrl } from "../../lib/utils";
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 
@@ -264,9 +265,10 @@ export const ParticipatingBooths: React.FC<ParticipatingBoothsProps> = ({ eventI
         return matchesSearch;
     });
 
-    const getImageSrc = (src?: string | null) => (
-        src && !failedImageUrls.has(src) ? src : BOOTH_IMAGE_FALLBACK_SRC
-    );
+    const getImageSrc = (src?: string | null) => {
+        if (!src || failedImageUrls.has(src)) return BOOTH_IMAGE_FALLBACK_SRC;
+        return getCdnImageUrl(src);
+    };
 
     const handleImageError = (
         event: React.SyntheticEvent<HTMLImageElement>,


### PR DESCRIPTION
## Summary
- promote explicit auth session checks and legacy CDN URL normalization from develop

## Verification
- npm run typecheck:changed
- develop PR #35 lint-and-build passed