### PR TITLE
Avoid protected API calls before anonymous guards settle

### DIFF
--- a/src/components/AdminRouteGuard.tsx
+++ b/src/components/AdminRouteGuard.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { hasAdminPermission } from '../utils/permissions';
 import { getRoleCode } from '../utils/role';
+import { useAuth } from '../context/AuthContext';
 
 interface AdminRouteGuardProps {
     children: React.ReactNode;
@@ -10,8 +11,16 @@ interface AdminRouteGuardProps {
 export const AdminRouteGuard: React.FC<AdminRouteGuardProps> = ({ children }) => {
     const [isAuthorized, setIsAuthorized] = useState<boolean | null>(null);
     const navigate = useNavigate();
+    const { isAuthenticated, loading } = useAuth();
 
     useEffect(() => {
+        if (loading) return;
+
+        if (!isAuthenticated) {
+            navigate('/login');
+            return;
+        }
+
         const check = async () => {
             const role = await getRoleCode();
             if (!role) {
@@ -25,7 +34,7 @@ export const AdminRouteGuard: React.FC<AdminRouteGuardProps> = ({ children }) =>
             }
         };
         check();
-    }, [navigate]);
+    }, [isAuthenticated, loading, navigate]);
 
     if (isAuthorized === null) {
         return (
@@ -40,5 +49,4 @@ export const AdminRouteGuard: React.FC<AdminRouteGuardProps> = ({ children }) =>
 
     return isAuthorized ? <>{children}</> : null;
 };
-
 

--- a/src/components/BoothAdminRouteGuard.tsx
+++ b/src/components/BoothAdminRouteGuard.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { hasBoothManagerPermission } from '../utils/permissions';
 import { getRoleCode } from '../utils/role';
+import { useAuth } from '../context/AuthContext';
 
 interface BoothAdminRouteGuardProps {
     children: React.ReactNode;
@@ -10,8 +11,16 @@ interface BoothAdminRouteGuardProps {
 export const BoothAdminRouteGuard: React.FC<BoothAdminRouteGuardProps> = ({ children }) => {
     const [isAuthorized, setIsAuthorized] = useState<boolean | null>(null);
     const navigate = useNavigate();
+    const { isAuthenticated, loading } = useAuth();
 
     useEffect(() => {
+        if (loading) return;
+
+        if (!isAuthenticated) {
+            navigate('/login');
+            return;
+        }
+
         const checkPermission = async () => {
             const roleCode = await getRoleCode();
 
@@ -28,7 +37,7 @@ export const BoothAdminRouteGuard: React.FC<BoothAdminRouteGuardProps> = ({ chil
         };
 
         checkPermission();
-    }, [navigate]);
+    }, [isAuthenticated, loading, navigate]);
 
     // 권한 확인 중이거나 권한이 없는 경우 로딩 표시
     if (isAuthorized === null) {

--- a/src/components/HostRouteGuard.tsx
+++ b/src/components/HostRouteGuard.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { hasHostPermission } from '../utils/permissions';
 import { getRoleCode } from '../utils/role';
+import { useAuth } from '../context/AuthContext';
 
 interface HostRouteGuardProps {
     children: React.ReactNode;
@@ -10,8 +11,16 @@ interface HostRouteGuardProps {
 export const HostRouteGuard: React.FC<HostRouteGuardProps> = ({ children }) => {
     const [isAuthorized, setIsAuthorized] = useState<boolean | null>(null);
     const navigate = useNavigate();
+    const { isAuthenticated, loading } = useAuth();
 
     useEffect(() => {
+        if (loading) return;
+
+        if (!isAuthenticated) {
+            navigate('/login');
+            return;
+        }
+
         const checkPermission = async () => {
             const roleCode = await getRoleCode();
 
@@ -28,7 +37,7 @@ export const HostRouteGuard: React.FC<HostRouteGuardProps> = ({ children }) => {
         };
 
         checkPermission();
-    }, [navigate]);
+    }, [isAuthenticated, loading, navigate]);
 
     // 권한 확인 중이거나 권한이 없는 경우 로딩 표시
     if (isAuthorized === null) {

--- a/src/pages/user_booth/BoothExperienceList.tsx
+++ b/src/pages/user_booth/BoothExperienceList.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Search, Filter, Clock, Users, MapPin, Calendar } from 'lucide-react';
 import { HiOutlineMenu, HiOutlineX } from "react-icons/hi";
 import {
@@ -8,7 +8,6 @@ import {
   formatTime
 } from '../../services/boothExperienceService';
 import { BoothExperience, BoothExperienceFilters } from '../../services/types/boothExperienceType';
-import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { AttendeeSideNav } from "../../pages/user_mypage/AttendeeSideNav";
 import { TopNav } from "../../components/TopNav";
@@ -16,11 +15,12 @@ import BoothExperienceReservationModal from '../../components/booth/BoothExperie
 import reservationService from '../../services/reservationService';
 import { useTranslation } from 'react-i18next';
 import { useScrollToTop } from '../../hooks/useScrollToTop';
+import { useAuth } from '../../context/AuthContext';
 
 const BoothExperienceList: React.FC = () => {
   useScrollToTop();
-  const navigate = useNavigate();
   const { t } = useTranslation();
+  const { isAuthenticated, loading: authLoading } = useAuth();
   const [experiences, setExperiences] = useState<BoothExperience[]>([]);
   const [filteredExperiences, setFilteredExperiences] = useState<BoothExperience[]>([]);
   const [loading, setLoading] = useState(true);
@@ -51,8 +51,17 @@ const BoothExperienceList: React.FC = () => {
 
   // 사용자 참가 신청 행사 목록 로딩
   useEffect(() => {
+    if (authLoading) return;
+
+    if (!isAuthenticated) {
+      setUserRegisteredEvents([]);
+      setAvailableEvents([]);
+      setUserEventsLoaded(true);
+      return;
+    }
+
     loadUserRegisteredEvents();
-  }, []);
+  }, [authLoading, isAuthenticated]);
 
   // 데이터 로딩 - 사용자 행사 로딩이 완료된 후에 체험을 로딩
   useEffect(() => {
@@ -346,7 +355,7 @@ const BoothExperienceList: React.FC = () => {
                             if (input.showPicker) {
                               try {
                                 input.showPicker();
-                              } catch (error) {
+                              } catch {
                                 console.log('showPicker failed, falling back to focus');
                                 input.focus();
                               }
@@ -384,7 +393,7 @@ const BoothExperienceList: React.FC = () => {
                             if (input.showPicker) {
                               try {
                                 input.showPicker();
-                              } catch (error) {
+                              } catch {
                                 console.log('showPicker failed, falling back to focus');
                                 input.focus();
                               }
@@ -411,7 +420,7 @@ const BoothExperienceList: React.FC = () => {
                         boxShadow: 'none'
                       }}
                       value={sortBy}
-                      onChange={(e) => setSortBy(e.target.value as any)}
+                      onChange={(e) => setSortBy(e.target.value as 'congestionRate' | 'startTime' | 'createdAt')}
                     >
                       <option value="startTime" style={{ backgroundColor: 'white', color: '#374151', padding: '8px 12px' }}>{t('boothExperience.sortByTime')}</option>
                       <option value="congestionRate" style={{ backgroundColor: 'white', color: '#374151', padding: '8px 12px' }}>{t('boothExperience.sortByCongestion')}</option>


### PR DESCRIPTION
## Summary
- wait for AuthContext before route guards call the role API
- skip user reservation loading on the public booth-experience list when anonymous
- keep authenticated-only reservation filtering available after login

## Verification
- npm run typecheck:changed
- npm run lint:changed
- npm run route:check
- npm run build